### PR TITLE
Add frontend duplicate management UI and API client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
 lib64/
 parts/
 sdist/
@@ -69,6 +70,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
 lib64/
 parts/
 sdist/
@@ -138,6 +140,7 @@ docs/_build/
 
 # Custom
 /logs/
+!frontend/src/app/logs/
 /cache/
 /.diskcache/
 /screenshots/

--- a/backend/ingestion_orchestration_fastapi_app/README.md
+++ b/backend/ingestion_orchestration_fastapi_app/README.md
@@ -200,6 +200,13 @@ Result: {'total_processed': 25, 'total_failed': 0}
 
 GPU-side logs show that each 8-image batch took ~11 s; batching is now the main optimisation target.
 
+## Duplicate & Curation Endpoints
+
+- `POST /api/v1/duplicates/find-similar` – run near-duplicate analysis in the background
+- `GET /api/v1/duplicates/report/{task_id}` – retrieve progress and results
+- `POST /api/v1/duplicates/archive-exact` – move exact duplicates to `_VibeDuplicates`
+- `POST /api/v1/curation/archive-selection` – archive selected images with a collection snapshot
+
 ## Potential Next Steps (Roadmap as of 2025-06-12)
 
 1.  **Increase ML batch size** – raise `ML_INFERENCE_BATCH_SIZE` default to `128` and/or fetch the safe value probed by the ML service at runtime.  This will cut GPU cycles by ~3× for small-to-medium ingest runs.

--- a/backend/ingestion_orchestration_fastapi_app/main.py
+++ b/backend/ingestion_orchestration_fastapi_app/main.py
@@ -12,7 +12,7 @@ import asyncio
 
 # Import the global state manager and the routers
 from .dependencies import app_state, get_qdrant_client
-from .routers import search, images, duplicates, random, collections, umap # and any others
+from .routers import search, images, duplicates, random, collections, umap, curation # and any others
 
 # Configure logging
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper())
@@ -75,6 +75,7 @@ app.include_router(duplicates.router)
 app.include_router(random.router)
 app.include_router(collections.router)
 app.include_router(umap.router)
+app.include_router(curation.router)
 
 # Import and include the ingest router
 from .routers import ingest
@@ -135,4 +136,4 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8002) 
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/backend/ingestion_orchestration_fastapi_app/routers/curation.py
+++ b/backend/ingestion_orchestration_fastapi_app/routers/curation.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, Body
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import PointIdsList
+from pydantic import BaseModel
+from typing import List
+import os
+import shutil
+import logging
+
+from ..dependencies import get_qdrant_client, get_active_collection
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/curation", tags=["curation"])
+
+
+class ArchiveSelectionRequest(BaseModel):
+    point_ids: List[str] = Body(..., description="IDs of points to archive")
+
+
+@router.post("/archive-selection")
+async def archive_selection(
+    req: ArchiveSelectionRequest,
+    qdrant: QdrantClient = Depends(get_qdrant_client),
+    collection_name: str = Depends(get_active_collection),
+):
+    """Archive selected images and remove their points."""
+    # Snapshot for safety
+    snapshot = qdrant.create_snapshot(collection_name=collection_name)
+    archived = []
+    for pid in req.point_ids:
+        try:
+            pts = qdrant.retrieve(
+                collection_name=collection_name,
+                ids=[pid],
+                with_payload=True,
+                with_vectors=False,
+            )
+            if not pts:
+                continue
+            payload = pts[0].payload or {}
+            path = payload.get("full_path")
+            if path and os.path.exists(path):
+                dest_dir = os.path.join(os.path.dirname(path), "_VibeArchive")
+                os.makedirs(dest_dir, exist_ok=True)
+                shutil.move(path, os.path.join(dest_dir, os.path.basename(path)))
+                archived.append(path)
+        except Exception as e:
+            logger.error(f"Failed to archive {pid}: {e}")
+    if req.point_ids:
+        qdrant.delete(
+            collection_name=collection_name,
+            points_selector=PointIdsList(points=req.point_ids),
+        )
+    return {"archived": archived, "snapshot": snapshot.name if snapshot else None}

--- a/backend/ingestion_orchestration_fastapi_app/routers/duplicates.py
+++ b/backend/ingestion_orchestration_fastapi_app/routers/duplicates.py
@@ -1,9 +1,8 @@
-from fastapi import APIRouter, HTTPException, Depends, Body, BackgroundTasks, Request
+from fastapi import APIRouter, HTTPException, Depends, Body, BackgroundTasks
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import SearchRequest, Filter, FieldCondition, ScoredPoint, PointStruct, UpdateStatus
-from typing import List, Dict, Any, Optional
+from qdrant_client.http.models import Filter, FieldCondition, PointStruct
+from typing import List, Dict, Any
 import logging
-import asyncio
 import uuid
 import os
 import shutil
@@ -20,6 +19,7 @@ router = APIRouter(prefix="/api/v1/duplicates", tags=["duplicates"])
 # In-memory storage for task status. In production, use Redis or a DB.
 tasks = {}
 
+
 class FindSimilarTask(BaseModel):
     task_id: str
     status: str = "pending"
@@ -27,6 +27,11 @@ class FindSimilarTask(BaseModel):
     total_points: int = 0
     processed_points: int = 0
     results: List[Dict[str, Any]] = []
+
+
+class ArchiveExactRequest(BaseModel):
+    file_paths: List[str]
+
 
 def find_similar_images_task(
     task_id: str,
@@ -40,14 +45,16 @@ def find_similar_images_task(
     Iterates through all points and finds those with a cosine similarity above the threshold.
     """
     tasks[task_id].status = "running"
-    logger.info(f"Task {task_id}: Starting near-duplicate analysis for collection '{collection_name}'.")
+    logger.info(
+        f"Task {task_id}: Starting near-duplicate analysis for collection '{collection_name}'."
+    )
 
     try:
         # Get total number of points for progress calculation
         collection_info = qdrant_client.get_collection(collection_name=collection_name)
         total_points = collection_info.points_count
         tasks[task_id].total_points = total_points
-        
+
         processed_ids = set()
         duplicate_groups = []
 
@@ -55,9 +62,9 @@ def find_similar_images_task(
         scroll_response = qdrant_client.scroll(
             collection_name=collection_name,
             with_vectors=True,
-            limit=100  # Adjust batch size as needed
+            limit=100,  # Adjust batch size as needed
         )
-        
+
         points_batch = scroll_response[0]
         next_page_offset = scroll_response[1]
 
@@ -68,50 +75,60 @@ def find_similar_images_task(
 
                 # Update progress
                 tasks[task_id].processed_points += 1
-                tasks[task_id].progress = (tasks[task_id].processed_points / total_points) * 100
+                tasks[task_id].progress = (
+                    tasks[task_id].processed_points / total_points
+                ) * 100
                 if tasks[task_id].processed_points % 100 == 0:
-                     logger.info(f"Task {task_id}: Progress {tasks[task_id].progress:.2f}% ({tasks[task_id].processed_points}/{total_points})")
-
+                    logger.info(
+                        f"Task {task_id}: Progress {tasks[task_id].progress:.2f}% ({tasks[task_id].processed_points}/{total_points})"
+                    )
 
                 search_results = qdrant_client.search(
                     collection_name=collection_name,
                     query_vector=point.vector,
-                    query_filter=Filter(must_not=[FieldCondition(key="id", match={"value": point.id})]),
+                    query_filter=Filter(
+                        must_not=[FieldCondition(key="id", match={"value": point.id})]
+                    ),
                     score_threshold=threshold,
-                    limit=limit_per_image
+                    limit=limit_per_image,
                 )
 
                 if search_results:
                     # Found a group of similar images
                     current_group_ids = {point.id}
-                    current_group_points = [{"id": point.id, "payload": point.payload, "score": 1.0}]
-                    
+                    current_group_points = [
+                        {"id": point.id, "payload": point.payload, "score": 1.0}
+                    ]
+
                     for sr in search_results:
                         current_group_ids.add(sr.id)
-                        current_group_points.append({"id": sr.id, "payload": sr.payload, "score": sr.score})
-                    
-                    duplicate_groups.append({
-                        "group_id": str(uuid.uuid4()),
-                        "points": current_group_points
-                    })
+                        current_group_points.append(
+                            {"id": sr.id, "payload": sr.payload, "score": sr.score}
+                        )
+
+                    duplicate_groups.append(
+                        {"group_id": str(uuid.uuid4()), "points": current_group_points}
+                    )
                     processed_ids.update(current_group_ids)
 
             if next_page_offset is None:
                 break
-            
+
             # Fetch the next batch
             scroll_response = qdrant_client.scroll(
                 collection_name=collection_name,
                 with_vectors=True,
                 limit=100,
-                offset=next_page_offset
+                offset=next_page_offset,
             )
             points_batch = scroll_response[0]
             next_page_offset = scroll_response[1]
 
         tasks[task_id].results = duplicate_groups
         tasks[task_id].status = "completed"
-        logger.info(f"Task {task_id}: Analysis complete. Found {len(duplicate_groups)} duplicate groups.")
+        logger.info(
+            f"Task {task_id}: Analysis complete. Found {len(duplicate_groups)} duplicate groups."
+        )
 
     except Exception as e:
         logger.error(f"Task {task_id}: Failed with error: {e}", exc_info=True)
@@ -121,10 +138,14 @@ def find_similar_images_task(
 @router.post("/find-similar", status_code=202, response_model=FindSimilarTask)
 async def find_similar(
     background_tasks: BackgroundTasks,
-    threshold: float = Body(0.98, ge=0.8, le=1.0, description="Similarity threshold for duplicates."),
-    limit_per_image: int = Body(10, ge=1, le=50, description="Max duplicates per image."),
+    threshold: float = Body(
+        0.98, ge=0.8, le=1.0, description="Similarity threshold for duplicates."
+    ),
+    limit_per_image: int = Body(
+        10, ge=1, le=50, description="Max duplicates per image."
+    ),
     qdrant: QdrantClient = Depends(get_qdrant_client),
-    collection_name: str = Depends(get_active_collection)
+    collection_name: str = Depends(get_active_collection),
 ):
     """
     Triggers a background task to find visually similar images in the collection.
@@ -132,17 +153,18 @@ async def find_similar(
     task_id = str(uuid.uuid4())
     task = FindSimilarTask(task_id=task_id)
     tasks[task_id] = task
-    
+
     background_tasks.add_task(
         find_similar_images_task,
         task_id,
         qdrant,
         collection_name,
         threshold,
-        limit_per_image
+        limit_per_image,
     )
-    
+
     return task
+
 
 @router.get("/report/{task_id}", response_model=FindSimilarTask)
 async def get_similar_report(task_id: str):
@@ -153,3 +175,21 @@ async def get_similar_report(task_id: str):
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return task
+
+
+@router.post("/archive-exact")
+async def archive_exact_duplicates(
+    req: ArchiveExactRequest,
+):
+    """Move the given file paths to a _VibeDuplicates folder on the same drive."""
+    archived = []
+    for path in req.file_paths:
+        try:
+            if os.path.exists(path):
+                dest_dir = os.path.join(os.path.dirname(path), "_VibeDuplicates")
+                os.makedirs(dest_dir, exist_ok=True)
+                shutil.move(path, os.path.join(dest_dir, os.path.basename(path)))
+                archived.append(path)
+        except Exception as e:
+            logger.error(f"Failed to archive {path}: {e}")
+    return {"archived": archived}

--- a/frontend/src/app/duplicates/page.tsx
+++ b/frontend/src/app/duplicates/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useRef } from "react";
+import {
+  Box,
+  Button,
+  Heading,
+  VStack,
+  HStack,
+  Text,
+  Checkbox,
+  Spinner,
+  Alert,
+  AlertIcon,
+  SimpleGrid,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Header } from "@/components/Header";
+import { useStore } from "@/store/useStore";
+import {
+  startFindSimilar,
+  getFindSimilarReport,
+  archiveSelection,
+  FindSimilarTask,
+} from "@/lib/api";
+
+export default function DuplicatesPage() {
+  const { collection } = useStore();
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  const startMutation = useMutation({
+    mutationFn: () => startFindSimilar(0.98, 10),
+    onSuccess: (data) => {
+      setTaskId(data.task_id);
+    },
+  });
+
+  const { data: report, isLoading } = useQuery<FindSimilarTask | null>({
+    queryKey: ["dup-report", taskId],
+    queryFn: () =>
+      taskId ? getFindSimilarReport(taskId) : Promise.resolve(null),
+    enabled: !!taskId,
+    refetchInterval: taskId ? 5000 : false,
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveSelection(Array.from(selected)),
+    onSuccess: () => setSelected(new Set()),
+  });
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <Box minH="100vh">
+      <Header />
+      <Box p={8}>
+        <Heading mb={4}>Duplicate Management</Heading>
+        {!collection && (
+          <Alert status="warning" mb={4}>
+            <AlertIcon />
+            Please select a collection first.
+          </Alert>
+        )}
+        <VStack align="start" spacing={4}>
+          <Button
+            colorScheme="blue"
+            onClick={() => startMutation.mutate()}
+            isLoading={startMutation.isLoading}
+            isDisabled={!collection || !!taskId}
+          >
+            Start Analysis
+          </Button>
+          {isLoading && (
+            <HStack>
+              <Spinner size="sm" />
+              <Text>Scanning collection...</Text>
+            </HStack>
+          )}
+          {report && (
+            <Box w="full">
+              <Text mb={2}>Status: {report.status}</Text>
+              <Text mb={4}>Progress: {report.progress.toFixed(2)}%</Text>
+              {report.status === "completed" && (
+                <VStack align="start" spacing={4}>
+                  <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+                    {report.results.map((group) => (
+                      <Box
+                        key={group.group_id}
+                        borderWidth="1px"
+                        p={3}
+                        borderRadius="md"
+                      >
+                        <Text fontWeight="bold" mb={2}>
+                          Group {group.group_id}
+                        </Text>
+                        {group.points.map((p: any) => (
+                          <HStack key={p.id} justify="space-between">
+                            <Checkbox
+                              isChecked={selected.has(p.id)}
+                              onChange={() => toggleSelect(p.id)}
+                            />
+                            <Text fontSize="sm" noOfLines={1}>
+                              {p.payload?.filename || p.id}
+                            </Text>
+                          </HStack>
+                        ))}
+                      </Box>
+                    ))}
+                  </SimpleGrid>
+                  <Button
+                    colorScheme="red"
+                    onClick={onOpen}
+                    isDisabled={selected.size === 0}
+                    isLoading={archiveMutation.isLoading}
+                  >
+                    Archive Selection
+                  </Button>
+                </VStack>
+              )}
+            </Box>
+          )}
+        </VStack>
+      </Box>
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Archive Selection
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              Are you sure you want to archive {selected.size} image(s)?
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose} mr={3}>
+                Cancel
+              </Button>
+              <Button
+                colorScheme="red"
+                onClick={() => archiveMutation.mutate()}
+                isLoading={archiveMutation.isLoading}
+              >
+                Archive
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Box>
+  );
+}

--- a/frontend/src/app/latent-space/components/UMAPScatterPlot.tsx
+++ b/frontend/src/app/latent-space/components/UMAPScatterPlot.tsx
@@ -1,33 +1,56 @@
-'use client';
+"use client";
 
-import React, { useMemo, useEffect, useState } from 'react';
-import { Box, Spinner, Center, Text, VStack, Alert, AlertIcon, Badge, HStack, Divider, Button } from '@chakra-ui/react';
-import { UMAPProjectionResponse, UMAPPoint } from '../types/latent-space';
-import { 
-  getEnhancedClusterColor, 
+import React, { useMemo, useEffect, useState } from "react";
+import {
+  Box,
+  Spinner,
+  Center,
+  Text,
+  VStack,
+  Alert,
+  AlertIcon,
+  Badge,
+  HStack,
+  Divider,
+  Button,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+} from "@chakra-ui/react";
+import { UMAPProjectionResponse, UMAPPoint } from "../types/latent-space";
+import {
+  getEnhancedClusterColor,
   getClusterColor,
   calculateBounds,
   ColorPaletteName,
   calculateClusterStatistics,
   getAnimatedClusterColor,
   getClusterSummary,
-  getComplement
-} from '../utils/visualization';
-import { COORDINATE_SYSTEM, OrthographicView } from '@deck.gl/core';
-import { luma } from '@luma.gl/core';
-import { webgl2Adapter } from '@luma.gl/webgl';
-import { useLatentSpaceStore } from '../hooks/useLatentSpaceStore';
-import { interpolateRgb } from 'd3-interpolate';
-import { Delaunay } from 'd3-delaunay';
-import { api, selectCollection as selectCollectionApi } from '@/lib/api';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useStore } from '@/store/useStore';
+  getComplement,
+} from "../utils/visualization";
+import { COORDINATE_SYSTEM, OrthographicView } from "@deck.gl/core";
+import { luma } from "@luma.gl/core";
+import { webgl2Adapter } from "@luma.gl/webgl";
+import { useLatentSpaceStore } from "../hooks/useLatentSpaceStore";
+import { interpolateRgb } from "d3-interpolate";
+import { Delaunay } from "d3-delaunay";
+import {
+  api,
+  selectCollection as selectCollectionApi,
+  archiveSelection,
+} from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useStore } from "@/store/useStore";
 // Dynamic drawing layer
-import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import { point as turfPoint } from '@turf/helpers';
+import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
+import { point as turfPoint } from "@turf/helpers";
 
 // Lazy load DeckGL to avoid SSR issues
-const DeckGL = React.lazy(() => import('@deck.gl/react'));
+const DeckGL = React.lazy(() => import("@deck.gl/react"));
 
 interface UMAPScatterPlotProps {
   data: UMAPProjectionResponse | null;
@@ -47,7 +70,7 @@ try {
   luma.registerAdapters?.([webgl2Adapter]);
 } catch (err) {
   /* eslint-disable no-console */
-  console.warn('[UMAPScatterPlot] WebGL2 adapter registration failed', err);
+  console.warn("[UMAPScatterPlot] WebGL2 adapter registration failed", err);
 }
 
 export function UMAPScatterPlot({
@@ -55,7 +78,7 @@ export function UMAPScatterPlot({
   onPointHover,
   onPointClick,
   selectedClusterId,
-  colorPalette = 'observable',
+  colorPalette = "observable",
   showOutliers = true,
   pointSize = 10,
 }: UMAPScatterPlotProps) {
@@ -69,9 +92,13 @@ export function UMAPScatterPlot({
   const projectionData = useLatentSpaceStore((s) => s.projectionData);
   const [screenPoly, _setScreenPoly] = useState<[number, number][]>([]);
   const screenPolyRef = React.useRef<[number, number][]>([]);
-  const setScreenPoly = (value: [number, number][] | ((prev: [number, number][]) => [number, number][])) => {
+  const setScreenPoly = (
+    value:
+      | [number, number][]
+      | ((prev: [number, number][]) => [number, number][]),
+  ) => {
     _setScreenPoly((prev) => {
-      const newVal = typeof value === 'function' ? (value as any)(prev) : value;
+      const newVal = typeof value === "function" ? (value as any)(prev) : value;
       screenPolyRef.current = newVal;
       return newVal;
     });
@@ -83,7 +110,7 @@ export function UMAPScatterPlot({
   useEffect(() => {
     let animationId: number;
     let startTime: number;
-    
+
     const animate = (currentTime: number) => {
       if (!startTime) startTime = currentTime;
       const elapsed = currentTime - startTime;
@@ -91,11 +118,11 @@ export function UMAPScatterPlot({
       setAnimationProgress(progress);
       animationId = requestAnimationFrame(animate);
     };
-    
+
     if (selectedClusterId !== null || hoveredPoint) {
       animationId = requestAnimationFrame(animate);
     }
-    
+
     return () => {
       if (animationId) cancelAnimationFrame(animationId);
     };
@@ -103,7 +130,7 @@ export function UMAPScatterPlot({
 
   // Debug logging
   useEffect(() => {
-    console.log('🎨 UMAPScatterPlot render:', {
+    console.log("🎨 UMAPScatterPlot render:", {
       hasData: !!data,
       pointsCount: data?.points?.length,
       selectedClusterId,
@@ -117,14 +144,14 @@ export function UMAPScatterPlot({
   // === Keyboard shortcuts ===
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'l' || e.key === 'L') setLassoMode(!lassoMode);
-      if (e.key === 'Escape') {
+      if (e.key === "l" || e.key === "L") setLassoMode(!lassoMode);
+      if (e.key === "Escape") {
         setLassoMode(false);
         setScreenPoly([]);
       }
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [lassoMode, setLassoMode]);
 
   // === Create collection mutation ===
@@ -136,19 +163,19 @@ export function UMAPScatterPlot({
         source_collection: data.collection,
         point_ids: payload.ids,
       };
-      const res = await api.post('/api/v1/collections/from_selection', body);
+      const res = await api.post("/api/v1/collections/from_selection", body);
       return res.data;
     },
     onSuccess: async (data, variables) => {
       setSelectedIds([]);
-      queryClient.invalidateQueries({ queryKey: ['collections'] });
+      queryClient.invalidateQueries({ queryKey: ["collections"] });
       // Automatically set new collection active both locally and on server
       const newCol = variables.newName;
       try {
         await selectCollectionApi(newCol);
       } catch (e) {
         // non-fatal
-        console.warn('Failed to set active collection', e);
+        console.warn("Failed to set active collection", e);
       }
       // optimistic local update
       const setCollection = useStore.getState().setCollection;
@@ -157,11 +184,25 @@ export function UMAPScatterPlot({
     },
   });
 
-  const [newName, setNewName] = useState('');
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveSelection(selectedIds),
+    onSuccess: () => setSelectedIds([]),
+  });
+
+  const [newName, setNewName] = useState("");
   const [showModal, setShowModal] = useState(false);
+  const {
+    isOpen: isArchiveOpen,
+    onOpen: openArchive,
+    onClose: closeArchive,
+  } = useDisclosure();
+  const cancelRef = React.useRef<HTMLButtonElement | null>(null);
 
   // GeoJSON for drawing
-  const [lassoGeoJson, setLassoGeoJson] = React.useState<any>({ type: 'FeatureCollection', features: [] });
+  const [lassoGeoJson, setLassoGeoJson] = React.useState<any>({
+    type: "FeatureCollection",
+    features: [],
+  });
 
   if (!data) {
     return (
@@ -178,18 +219,31 @@ export function UMAPScatterPlot({
     return (
       <Center h={600} bg="gray.50" borderRadius="md">
         <VStack>
-          <Text fontSize="lg" color="gray.600">No points to visualize</Text>
-          <Text fontSize="sm" color="gray.500">Add images to your collection to see them here</Text>
+          <Text fontSize="lg" color="gray.600">
+            No points to visualize
+          </Text>
+          <Text fontSize="sm" color="gray.500">
+            Add images to your collection to see them here
+          </Text>
         </VStack>
       </Center>
     );
   }
 
-  console.log('🎯 Rendering visualization with', data.points.length, 'points');
-  
+  console.log("🎯 Rendering visualization with", data.points.length, "points");
+
   return (
-    <Box w="100%" position="relative" h="600px" bg="white" borderRadius="md" border="1px solid" borderColor="gray.200" overflow="hidden">
-      <React.Suspense 
+    <Box
+      w="100%"
+      position="relative"
+      h="600px"
+      bg="white"
+      borderRadius="md"
+      border="1px solid"
+      borderColor="gray.200"
+      overflow="hidden"
+    >
+      <React.Suspense
         fallback={
           <Center h="600px">
             <VStack>
@@ -199,9 +253,12 @@ export function UMAPScatterPlot({
           </Center>
         }
       >
-                    <EnhancedDeckGLVisualization deckRef={deckRef} lassoGeoJson={lassoGeoJson} setLassoGeoJson={setLassoGeoJson}
-              points={data.points} 
-              onPointHover={(point) => {
+        <EnhancedDeckGLVisualization
+          deckRef={deckRef}
+          lassoGeoJson={lassoGeoJson}
+          setLassoGeoJson={setLassoGeoJson}
+          points={data.points}
+          onPointHover={(point) => {
             setHoveredPoint(point);
             onPointHover?.(point);
           }}
@@ -212,39 +269,40 @@ export function UMAPScatterPlot({
           pointSize={pointSize}
         />
       </React.Suspense>
-      
+
       {/* Enhanced info overlays */}
-      <Box 
-        position="absolute" 
-        top={3} 
-        left={3} 
-        bg="blackAlpha.800" 
-        color="white" 
-        px={3} 
-        py={2} 
-        borderRadius="md" 
+      <Box
+        position="absolute"
+        top={3}
+        left={3}
+        bg="blackAlpha.800"
+        color="white"
+        px={3}
+        py={2}
+        borderRadius="md"
         fontSize="sm"
         fontWeight="medium"
         backdropFilter="blur(4px)"
       >
         <Text>{data.points.length} points</Text>
         <Text fontSize="xs" opacity={0.8}>
-          {data.clustering_info?.n_clusters || 0} clusters • {colorPalette} palette
+          {data.clustering_info?.n_clusters || 0} clusters • {colorPalette}{" "}
+          palette
         </Text>
       </Box>
-      
+
       {/* Enhanced hover tooltip with cluster summary */}
       {hoveredPoint && (
-        <Box 
-          position="absolute" 
-          top={3} 
-          right={3} 
-          bg="blackAlpha.900" 
-          color="white" 
-          px={4} 
-          py={3} 
-          borderRadius="lg" 
-          fontSize="sm" 
+        <Box
+          position="absolute"
+          top={3}
+          right={3}
+          bg="blackAlpha.900"
+          color="white"
+          px={4}
+          py={3}
+          borderRadius="lg"
+          fontSize="sm"
           maxW="320px"
           backdropFilter="blur(8px)"
           boxShadow="2xl"
@@ -254,9 +312,11 @@ export function UMAPScatterPlot({
           <VStack align="start" spacing={2}>
             <HStack justify="space-between" w="full">
               <Text fontWeight="bold" fontSize="md" isTruncated maxW="200px">
-                {hoveredPoint.filename || `Point ${hoveredPoint.id.slice(0, 8)}`}
+                {hoveredPoint.filename ||
+                  `Point ${hoveredPoint.id.slice(0, 8)}`}
               </Text>
-              {(hoveredPoint.cluster_id !== null && hoveredPoint.cluster_id !== undefined) ? (
+              {hoveredPoint.cluster_id !== null &&
+              hoveredPoint.cluster_id !== undefined ? (
                 <Badge colorScheme="purple" variant="solid" fontSize="xs">
                   Cluster {hoveredPoint.cluster_id}
                 </Badge>
@@ -266,18 +326,25 @@ export function UMAPScatterPlot({
                 </Badge>
               )}
             </HStack>
-            
+
             <Divider opacity={0.3} />
-            
+
             <VStack align="start" spacing={1} fontSize="xs">
               <HStack>
                 <Text color="gray.300">Position:</Text>
-                <Text>({hoveredPoint.x.toFixed(2)}, {hoveredPoint.y.toFixed(2)})</Text>
+                <Text>
+                  ({hoveredPoint.x.toFixed(2)}, {hoveredPoint.y.toFixed(2)})
+                </Text>
               </HStack>
-              
-              {(hoveredPoint.cluster_id !== null && hoveredPoint.cluster_id !== undefined && data?.points) ? (
+
+              {hoveredPoint.cluster_id !== null &&
+              hoveredPoint.cluster_id !== undefined &&
+              data?.points ? (
                 (() => {
-                  const summary = getClusterSummary(data.points, hoveredPoint.cluster_id!);
+                  const summary = getClusterSummary(
+                    data.points,
+                    hoveredPoint.cluster_id!,
+                  );
                   return (
                     <>
                       <HStack>
@@ -297,18 +364,26 @@ export function UMAPScatterPlot({
                   <Text>No clustering applied</Text>
                 </HStack>
               )}
-              
+
               {hoveredPoint.is_outlier && (
                 <HStack>
-                  <Text color="red.300" fontWeight="medium">🔍 Outlier</Text>
+                  <Text color="red.300" fontWeight="medium">
+                    🔍 Outlier
+                  </Text>
                 </HStack>
               )}
             </VStack>
-            
+
             {hoveredPoint.caption && (
               <>
                 <Divider opacity={0.3} />
-                <Text fontSize="xs" color="gray.200" lineHeight="1.4" isTruncated maxW="280px">
+                <Text
+                  fontSize="xs"
+                  color="gray.200"
+                  lineHeight="1.4"
+                  isTruncated
+                  maxW="280px"
+                >
                   {hoveredPoint.caption}
                 </Text>
               </>
@@ -316,6 +391,35 @@ export function UMAPScatterPlot({
           </VStack>
         </Box>
       )}
+
+      <AlertDialog
+        isOpen={isArchiveOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={closeArchive}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Archive Selection
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              Are you sure you want to archive {selectedIds.length} image(s)?
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={closeArchive} mr={3}>
+                Cancel
+              </Button>
+              <Button
+                colorScheme="red"
+                onClick={() => archiveMutation.mutate()}
+                isLoading={archiveMutation.isLoading}
+              >
+                Archive
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
 
       {/* Cluster selection indicator */}
       {selectedClusterId !== null && selectedClusterId !== undefined && (
@@ -337,27 +441,90 @@ export function UMAPScatterPlot({
 
       {/* Create collection bar */}
       {selectedIds.length > 0 && (
-        <Box position="fixed" bottom={6} left="50%" transform="translateX(-50%)" zIndex={3000} bg="white" _dark={{bg:'gray.800'}} px={4} py={2} borderRadius="md" boxShadow="xl" border="1px solid" borderColor="gray.300" _dark={{borderColor:'gray.600'}}>
+        <Box
+          position="fixed"
+          bottom={6}
+          left="50%"
+          transform="translateX(-50%)"
+          zIndex={3000}
+          bg="white"
+          _dark={{ bg: "gray.800" }}
+          px={4}
+          py={2}
+          borderRadius="md"
+          boxShadow="xl"
+          border="1px solid"
+          borderColor="gray.300"
+          _dark={{ borderColor: "gray.600" }}
+        >
           <HStack spacing={3}>
             <Text>{selectedIds.length} selected</Text>
-            <Button size="sm" colorScheme="green" onClick={() => setShowModal(true)}>
+            <Button
+              size="sm"
+              colorScheme="green"
+              onClick={() => setShowModal(true)}
+            >
               Create Collection
             </Button>
-            <Button size="sm" variant="ghost" onClick={() => setSelectedIds([])}>Clear</Button>
+            <Button
+              size="sm"
+              colorScheme="red"
+              onClick={openArchive}
+              isLoading={archiveMutation.isLoading}
+            >
+              Archive Selection
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setSelectedIds([])}
+            >
+              Clear
+            </Button>
           </HStack>
         </Box>
       )}
 
       {/* Modal */}
       {showModal && (
-        <Box position="fixed" inset={0} bg="blackAlpha.600" zIndex={1000} display="flex" alignItems="center" justifyContent="center">
-          <Box bg="white" _dark={{bg:'gray.700'}} p={6} borderRadius="md" minW="300px">
+        <Box
+          position="fixed"
+          inset={0}
+          bg="blackAlpha.600"
+          zIndex={1000}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Box
+            bg="white"
+            _dark={{ bg: "gray.700" }}
+            p={6}
+            borderRadius="md"
+            minW="300px"
+          >
             <VStack spacing={4}>
               <Text fontWeight="bold">New Collection Name</Text>
-              <input style={{width:'100%', padding:'6px'}} value={newName} onChange={(e)=>setNewName(e.target.value)} />
+              <input
+                style={{ width: "100%", padding: "6px" }}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
               <HStack>
-                <Button size="sm" colorScheme="green" isDisabled={!newName} isLoading={createMutation.isPending} onClick={() => createMutation.mutate({ newName, ids: selectedIds })}>Create</Button>
-                <Button size="sm" onClick={()=> setShowModal(false)}>Cancel</Button>
+                <Button
+                  size="sm"
+                  colorScheme="green"
+                  isDisabled={!newName}
+                  isLoading={createMutation.isPending}
+                  onClick={() =>
+                    createMutation.mutate({ newName, ids: selectedIds })
+                  }
+                >
+                  Create
+                </Button>
+                <Button size="sm" onClick={() => setShowModal(false)}>
+                  Cancel
+                </Button>
               </HStack>
             </VStack>
           </Box>
@@ -373,8 +540,15 @@ export function UMAPScatterPlot({
         ref={overlayRef}
       >
         {screenPoly.length > 1 && (
-          <svg style={{position:'absolute',inset:0,pointerEvents:'none'}}>
-            <polyline points={screenPoly.map(p=>p.join(',')).join(' ')} fill="none" stroke="teal" strokeWidth="2" />
+          <svg
+            style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+          >
+            <polyline
+              points={screenPoly.map((p) => p.join(",")).join(" ")}
+              fill="none"
+              stroke="teal"
+              strokeWidth="2"
+            />
           </svg>
         )}
       </Box>
@@ -382,17 +556,17 @@ export function UMAPScatterPlot({
   );
 }
 
-function EnhancedDeckGLVisualization({ 
+function EnhancedDeckGLVisualization({
   deckRef,
-  points, 
-  onPointHover, 
-  onPointClick, 
+  points,
+  onPointHover,
+  onPointClick,
   selectedClusterId,
-  colorPalette = 'observable',
+  colorPalette = "observable",
   showOutliers = true,
   pointSize = 10,
   lassoGeoJson,
-  setLassoGeoJson
+  setLassoGeoJson,
 }: {
   deckRef: React.RefObject<any>;
   points: UMAPPoint[];
@@ -406,15 +580,24 @@ function EnhancedDeckGLVisualization({
   setLassoGeoJson: React.Dispatch<React.SetStateAction<any>>;
 }) {
   const [DeckGLComponent, setDeckGLComponent] = React.useState<any>(null);
-  const [ScatterplotLayerComponent, setScatterplotLayerComponent] = React.useState<any>(null);
-  const [HeatmapLayerComponent, setHeatmapLayerComponent] = React.useState<any>(null);
-  const [PolygonLayerComponent, setPolygonLayerComponent] = React.useState<any>(null);
+  const [ScatterplotLayerComponent, setScatterplotLayerComponent] =
+    React.useState<any>(null);
+  const [HeatmapLayerComponent, setHeatmapLayerComponent] =
+    React.useState<any>(null);
+  const [PolygonLayerComponent, setPolygonLayerComponent] =
+    React.useState<any>(null);
   const [PathLayerComponent, setPathLayerComponent] = React.useState<any>(null);
-  const [EditableGeoJsonLayerComponent, setEditableGeoJsonLayerComponent] = React.useState<any>(null);
-  const [DrawPolygonByDraggingModeComponent, setDrawPolygonByDraggingModeComponent] = React.useState<any>(null);
+  const [EditableGeoJsonLayerComponent, setEditableGeoJsonLayerComponent] =
+    React.useState<any>(null);
+  const [
+    DrawPolygonByDraggingModeComponent,
+    setDrawPolygonByDraggingModeComponent,
+  ] = React.useState<any>(null);
   const [ViewModeComponent, setViewModeComponent] = React.useState<any>(null);
   const [error, setError] = React.useState<string | null>(null);
-  const [hoveredObject, setHoveredObject] = React.useState<UMAPPoint | null>(null);
+  const [hoveredObject, setHoveredObject] = React.useState<UMAPPoint | null>(
+    null,
+  );
   const selectedIds = useLatentSpaceStore((s) => s.selectedIds);
   const setSelectedIdsStore = useLatentSpaceStore((s) => s.setSelectedIds);
 
@@ -431,14 +614,18 @@ function EnhancedDeckGLVisualization({
   const showScatter = useLatentSpaceStore((s) => s.showScatter);
   const showHulls = useLatentSpaceStore((s) => s.showHulls);
   const showVoronoi = useLatentSpaceStore((s) => s.showVoronoi);
-  const showVoronoiFill = useLatentSpaceStore((s)=>s.showVoronoiFill);
-  const lassoMode = useLatentSpaceStore((s)=>s.lassoMode);
-  const setLassoMode = useLatentSpaceStore((s)=>s.setLassoMode);
-  const setSelectedPolygonStore = useLatentSpaceStore((s)=>s.setSelectedPolygon);
+  const showVoronoiFill = useLatentSpaceStore((s) => s.showVoronoiFill);
+  const lassoMode = useLatentSpaceStore((s) => s.lassoMode);
+  const setLassoMode = useLatentSpaceStore((s) => s.setLassoMode);
+  const setSelectedPolygonStore = useLatentSpaceStore(
+    (s) => s.setSelectedPolygon,
+  );
 
   // Resolve effective values: props override store when provided
-  const effectiveShowOutliers = showOutliers !== undefined ? showOutliers : storeShowOutliers;
-  const effectivePointSize = pointSize !== undefined ? pointSize : storePointSize;
+  const effectiveShowOutliers =
+    showOutliers !== undefined ? showOutliers : storeShowOutliers;
+  const effectivePointSize =
+    pointSize !== undefined ? pointSize : storePointSize;
   const effectiveColorPalette = colorPalette ?? storeColorPalette;
 
   useEffect(() => {
@@ -448,34 +635,40 @@ function EnhancedDeckGLVisualization({
         // deck.gl v9 requires WebGL2. Abort early if the browser/GPU cannot
         // create a WebGL2 context so we can show a friendly message instead
         // of crashing deep inside luma.gl internal code.
-        const testCanvas = document.createElement('canvas');
-        const gl2 = testCanvas.getContext('webgl2');
+        const testCanvas = document.createElement("canvas");
+        const gl2 = testCanvas.getContext("webgl2");
         if (!gl2) {
           throw new Error(
-            'WebGL2 is not supported in this browser / GPU. Enable hardware acceleration or use a more recent browser to view the 2-D embedding.'
+            "WebGL2 is not supported in this browser / GPU. Enable hardware acceleration or use a more recent browser to view the 2-D embedding.",
           );
         }
         // ====================================================================
 
-        console.log('📦 Loading DeckGL components...');
-        
-        const deckModule = await import('@deck.gl/react');
-        const layersModule = await import('@deck.gl/layers');
-        const aggModule = await import('@deck.gl/aggregation-layers');
-        const editableModule = await import('@deck.gl-community/editable-layers');
-        
-        console.log('✅ DeckGL components loaded');
+        console.log("📦 Loading DeckGL components...");
+
+        const deckModule = await import("@deck.gl/react");
+        const layersModule = await import("@deck.gl/layers");
+        const aggModule = await import("@deck.gl/aggregation-layers");
+        const editableModule = await import(
+          "@deck.gl-community/editable-layers"
+        );
+
+        console.log("✅ DeckGL components loaded");
         setDeckGLComponent(() => deckModule.default);
         setScatterplotLayerComponent(() => layersModule.ScatterplotLayer);
         setHeatmapLayerComponent(() => aggModule.HeatmapLayer);
         setPolygonLayerComponent(() => layersModule.PolygonLayer);
         setPathLayerComponent(() => layersModule.PathLayer);
-        setEditableGeoJsonLayerComponent(() => editableModule.EditableGeoJsonLayer);
-        setDrawPolygonByDraggingModeComponent(() => editableModule.DrawPolygonByDraggingMode);
+        setEditableGeoJsonLayerComponent(
+          () => editableModule.EditableGeoJsonLayer,
+        );
+        setDrawPolygonByDraggingModeComponent(
+          () => editableModule.DrawPolygonByDraggingMode,
+        );
         setViewModeComponent(() => editableModule.ViewMode);
       } catch (err) {
-        console.error('❌ Failed to load DeckGL:', err);
-        setError(err instanceof Error ? err.message : 'Failed to load DeckGL');
+        console.error("❌ Failed to load DeckGL:", err);
+        setError(err instanceof Error ? err.message : "Failed to load DeckGL");
       }
     };
 
@@ -484,34 +677,35 @@ function EnhancedDeckGLVisualization({
 
   // WebGL Debug Test - moved to proper hooks order
   useEffect(() => {
-    console.log('🧪 Testing WebGL support...');
+    console.log("🧪 Testing WebGL support...");
     try {
-      const canvas = document.createElement('canvas');
-      const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-      
+      const canvas = document.createElement("canvas");
+      const gl =
+        canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+
       if (gl) {
-        console.log('✅ WebGL is supported in browser');
-        console.log('🔍 WebGL info:', {
+        console.log("✅ WebGL is supported in browser");
+        console.log("🔍 WebGL info:", {
           version: gl.getParameter(gl.VERSION),
           vendor: gl.getParameter(gl.VENDOR),
-          renderer: gl.getParameter(gl.RENDERER)
+          renderer: gl.getParameter(gl.RENDERER),
         });
       } else {
-        console.log('❌ WebGL is not supported in browser');
+        console.log("❌ WebGL is not supported in browser");
       }
     } catch (error) {
-      console.log('❌ WebGL test failed:', error);
+      console.log("❌ WebGL test failed:", error);
     }
-    
+
     // Check for existing canvases
     setTimeout(() => {
-      const canvases = document.querySelectorAll('canvas');
+      const canvases = document.querySelectorAll("canvas");
       console.log(`🎨 Found ${canvases.length} canvas elements after render`);
       canvases.forEach((canvas, i) => {
         console.log(`Canvas ${i}:`, {
           width: canvas.width,
           height: canvas.height,
-          context: canvas.getContext('webgl') ? 'WebGL' : 'Other'
+          context: canvas.getContext("webgl") ? "WebGL" : "Other",
         });
       });
     }, 1000);
@@ -521,7 +715,11 @@ function EnhancedDeckGLVisualization({
     const bounds = calculateBounds(points, 0.15);
     const centerX = (bounds.minX + bounds.maxX) / 2;
     const centerY = (bounds.minY + bounds.maxY) / 2;
-    const maxDim = Math.max(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY, 0.1);
+    const maxDim = Math.max(
+      bounds.maxX - bounds.minX,
+      bounds.maxY - bounds.minY,
+      0.1,
+    );
     const zoom = Math.log2(600 / maxDim); // 600px canvas baseline
     return { target: [centerX, centerY, 0], zoom };
   }, [points]);
@@ -529,14 +727,14 @@ function EnhancedDeckGLVisualization({
   // previous detailed logging kept but tied to ortho bounds
   useEffect(() => {
     const bounds = calculateBounds(points, 0.15);
-    console.log('🗺️ Ortho bounds:', bounds);
-    console.log('🗺️ Ortho viewState:', orthoViewState);
+    console.log("🗺️ Ortho bounds:", bounds);
+    console.log("🗺️ Ortho viewState:", orthoViewState);
   }, [points, orthoViewState]);
 
   // Filter points based on showOutliers setting
   const filteredPoints = useMemo(() => {
     if (effectiveShowOutliers) return points;
-    return points.filter(point => !point.is_outlier);
+    return points.filter((point) => !point.is_outlier);
   }, [points, effectiveShowOutliers]);
 
   // Calculate cluster statistics for better color distribution
@@ -550,79 +748,130 @@ function EnhancedDeckGLVisualization({
     const layerList: any[] = [];
 
     // === Heatmap layers (under scatter) ===
-    if (overlayMode==='heatmap' && heatmapVisible && HeatmapLayerComponent) {
+    if (overlayMode === "heatmap" && heatmapVisible && HeatmapLayerComponent) {
       // Group points by cluster id (exclude outliers/unclustered)
       const clustersMap: Record<number, UMAPPoint[]> = {};
       filteredPoints.forEach((p) => {
-        if (p.cluster_id === undefined || p.cluster_id === null || p.cluster_id === -1) return;
-        if (selectedClusterId !== null && selectedClusterId !== undefined && p.cluster_id !== selectedClusterId) return; // Respect selection filtering
+        if (
+          p.cluster_id === undefined ||
+          p.cluster_id === null ||
+          p.cluster_id === -1
+        )
+          return;
+        if (
+          selectedClusterId !== null &&
+          selectedClusterId !== undefined &&
+          p.cluster_id !== selectedClusterId
+        )
+          return; // Respect selection filtering
         clustersMap[p.cluster_id] = clustersMap[p.cluster_id] || [];
         clustersMap[p.cluster_id].push(p);
       });
 
       Object.entries(clustersMap).forEach(([cidStr, pts]) => {
         const cid = Number(cidStr);
-        const baseColor = getClusterColor({ cluster_id: cid, is_outlier: false } as any, clusterStats.totalClusters, effectiveColorPalette).slice(0,3) as [number,number,number];
+        const baseColor = getClusterColor(
+          { cluster_id: cid, is_outlier: false } as any,
+          clusterStats.totalClusters,
+          effectiveColorPalette,
+        ).slice(0, 3) as [number, number, number];
         // HeatmapLayer expects colorRange[0] = HIGH intensity, [5] = LOW.
         // We want cluster centers (high weight) to be vivid, edges to fade to white.
         const colorRange = Array.from({ length: 6 }).map((_, idx) => {
           const t = idx / 5; // 0 → high, 1 → low
-          const rgb = interpolateRgb(`rgb(${baseColor[0]},${baseColor[1]},${baseColor[2]})`, `#ffffff`)(t);
+          const rgb = interpolateRgb(
+            `rgb(${baseColor[0]},${baseColor[1]},${baseColor[2]})`,
+            `#ffffff`,
+          )(t);
           const [r, g, b] = rgb.match(/\d+/g)!.map(Number);
           return [r, g, b, 255];
         });
 
-        layerList.push(new HeatmapLayerComponent({
-          id: `heatmap-${cid}`,
-          data: pts,
-          getPosition: (d: UMAPPoint) => [d.x, d.y],
-          getWeight: 1,
-          colorRange,
-          radiusPixels: terrainResolution * 6,
-          opacity: heatmapOpacity / 100,
-          aggregation: 'MEAN',
-          gpuAggregation: true,
-        }));
+        layerList.push(
+          new HeatmapLayerComponent({
+            id: `heatmap-${cid}`,
+            data: pts,
+            getPosition: (d: UMAPPoint) => [d.x, d.y],
+            getWeight: 1,
+            colorRange,
+            radiusPixels: terrainResolution * 6,
+            opacity: heatmapOpacity / 100,
+            aggregation: "MEAN",
+            gpuAggregation: true,
+          }),
+        );
       });
     }
 
     // ===== Polygon hull layers (under heatmap, under scatter) =====
-    if (showHulls && PolygonLayerComponent && Object.keys(clusterPolygons).length) {
+    if (
+      showHulls &&
+      PolygonLayerComponent &&
+      Object.keys(clusterPolygons).length
+    ) {
       Object.entries(clusterPolygons).forEach(([cidStr, hullCoords]) => {
         const cid = Number(cidStr);
-        if (selectedClusterId !== null && selectedClusterId !== undefined && cid !== selectedClusterId) return;
-        const baseColor = getClusterColor({ cluster_id: cid, is_outlier: false } as any, clusterStats.totalClusters, effectiveColorPalette);
-        const fillCol = [...baseColor.slice(0,3), 140]; // stronger fill alpha
+        if (
+          selectedClusterId !== null &&
+          selectedClusterId !== undefined &&
+          cid !== selectedClusterId
+        )
+          return;
+        const baseColor = getClusterColor(
+          { cluster_id: cid, is_outlier: false } as any,
+          clusterStats.totalClusters,
+          effectiveColorPalette,
+        );
+        const fillCol = [...baseColor.slice(0, 3), 140]; // stronger fill alpha
 
-        layerList.push(new PolygonLayerComponent({
-          id: `hull-${cid}`,
-          data: [{ polygon: hullCoords }],
-          getPolygon: (d:any)=>d.polygon,
-          stroked: true,
-          lineWidthUnits: 'pixels',
-          lineWidthMinPixels: 1,
-          filled: true,
-          getFillColor: fillCol,
-          getLineColor: baseColor,
-          pickable: false,
-          updateTriggers: { getFillColor: [effectiveColorPalette], getLineColor: [effectiveColorPalette] },
-        }));
+        layerList.push(
+          new PolygonLayerComponent({
+            id: `hull-${cid}`,
+            data: [{ polygon: hullCoords }],
+            getPolygon: (d: any) => d.polygon,
+            stroked: true,
+            lineWidthUnits: "pixels",
+            lineWidthMinPixels: 1,
+            filled: true,
+            getFillColor: fillCol,
+            getLineColor: baseColor,
+            pickable: false,
+            updateTriggers: {
+              getFillColor: [effectiveColorPalette],
+              getLineColor: [effectiveColorPalette],
+            },
+          }),
+        );
       });
     }
 
     // === Terrain overlay via blurred HeatmapLayer ===
-    if (overlayMode === 'terrain' && HeatmapLayerComponent) {
+    if (overlayMode === "terrain" && HeatmapLayerComponent) {
       const clusterGroups: Record<number, UMAPPoint[]> = {};
       filteredPoints.forEach((p) => {
-        if (p.cluster_id === undefined || p.cluster_id === null || p.cluster_id === -1) return;
-        if (selectedClusterId !== null && selectedClusterId !== undefined && p.cluster_id !== selectedClusterId) return;
+        if (
+          p.cluster_id === undefined ||
+          p.cluster_id === null ||
+          p.cluster_id === -1
+        )
+          return;
+        if (
+          selectedClusterId !== null &&
+          selectedClusterId !== undefined &&
+          p.cluster_id !== selectedClusterId
+        )
+          return;
         clusterGroups[p.cluster_id] = clusterGroups[p.cluster_id] || [];
         clusterGroups[p.cluster_id].push(p);
       });
 
       Object.entries(clusterGroups).forEach(([cidStr, pts]) => {
         const cid = Number(cidStr);
-        const baseColor = getClusterColor({ cluster_id: cid, is_outlier: false } as any, clusterStats.totalClusters, effectiveColorPalette).slice(0, 3);
+        const baseColor = getClusterColor(
+          { cluster_id: cid, is_outlier: false } as any,
+          clusterStats.totalClusters,
+          effectiveColorPalette,
+        ).slice(0, 3);
         const colorRange = Array.from({ length: 6 }).map((_, idx) => {
           const t = idx / 5;
           return [
@@ -643,9 +892,9 @@ function EnhancedDeckGLVisualization({
             radiusPixels: terrainResolution * 3,
             opacity: heatmapOpacity / 100,
             gpuAggregation: true,
-            aggregation: 'SUM',
+            aggregation: "SUM",
             coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-          })
+          }),
         );
       });
     }
@@ -654,17 +903,30 @@ function EnhancedDeckGLVisualization({
     if (showVoronoi && PathLayerComponent) {
       try {
         const bounds = calculateBounds(filteredPoints, 0.1);
-        const delaunay = Delaunay.from(filteredPoints, (d)=>d.x, (d)=>d.y);
-        const vor = delaunay.voronoi([bounds.minX, bounds.minY, bounds.maxX, bounds.maxY]);
+        const delaunay = Delaunay.from(
+          filteredPoints,
+          (d) => d.x,
+          (d) => d.y,
+        );
+        const vor = delaunay.voronoi([
+          bounds.minX,
+          bounds.minY,
+          bounds.maxX,
+          bounds.maxY,
+        ]);
         const paths: any[] = [];
         const cells: any[] = [];
         for (let i = 0; i < filteredPoints.length; i++) {
           const poly = vor.cellPolygon(i);
           if (!poly) continue;
           const pt = filteredPoints[i];
-          const color = getClusterColor(pt, clusterStats.totalClusters, effectiveColorPalette);
+          const color = getClusterColor(
+            pt,
+            clusterStats.totalClusters,
+            effectiveColorPalette,
+          );
           paths.push({
-            path: poly.map(([x,y])=>[x,y]),
+            path: poly.map(([x, y]) => [x, y]),
             cluster_id: pt.cluster_id,
             color,
           });
@@ -672,37 +934,41 @@ function EnhancedDeckGLVisualization({
           if (showVoronoiFill) {
             const fillColor = getComplement(color, 80);
             cells.push({
-              polygon: poly.map(([x,y])=>[x,y]),
+              polygon: poly.map(([x, y]) => [x, y]),
               cluster_id: pt.cluster_id,
               fillColor,
             });
           }
         }
 
-        layerList.push(new PathLayerComponent({
-          id: 'voronoi-borders',
-          data: paths,
-          getPath: (d:any)=>d.path,
-          getWidth: 2,
-          widthUnits: 'pixels',
-          getColor: (d:any)=>d.color,
-          pickable: false,
-        }));
+        layerList.push(
+          new PathLayerComponent({
+            id: "voronoi-borders",
+            data: paths,
+            getPath: (d: any) => d.path,
+            getWidth: 2,
+            widthUnits: "pixels",
+            getColor: (d: any) => d.color,
+            pickable: false,
+          }),
+        );
 
         if (showVoronoiFill && cells.length && PolygonLayerComponent) {
-          layerList.unshift(new PolygonLayerComponent({
-            id: 'voronoi-tiles',
-            data: cells,
-            getPolygon: (d:any)=>d.polygon,
-            getFillColor: (d:any)=>d.fillColor,
-            getLineColor: [0,0,0,0],
-            pickable: false,
-            parameters: { depthTest: false },
-            updateTriggers: { getFillColor: [effectiveColorPalette] },
-          }));
+          layerList.unshift(
+            new PolygonLayerComponent({
+              id: "voronoi-tiles",
+              data: cells,
+              getPolygon: (d: any) => d.polygon,
+              getFillColor: (d: any) => d.fillColor,
+              getLineColor: [0, 0, 0, 0],
+              pickable: false,
+              parameters: { depthTest: false },
+              updateTriggers: { getFillColor: [effectiveColorPalette] },
+            }),
+          );
         }
-      } catch(err){
-        console.warn('Voronoi computation failed', err);
+      } catch (err) {
+        console.warn("Voronoi computation failed", err);
       }
     }
 
@@ -714,42 +980,54 @@ function EnhancedDeckGLVisualization({
     ) {
       layerList.push(
         new EditableGeoJsonLayerComponent({
-          id: 'lasso',
+          id: "lasso",
           data: lassoGeoJson,
-          mode: lassoMode ? DrawPolygonByDraggingModeComponent : ViewModeComponent,
+          mode: lassoMode
+            ? DrawPolygonByDraggingModeComponent
+            : ViewModeComponent,
           pickable: lassoMode,
           parameters: { depthTest: false },
           getLineColor: [255, 255, 0],
           getLineWidth: 2,
-          getCursor: () => (lassoMode ? 'crosshair' : 'auto'),
+          getCursor: () => (lassoMode ? "crosshair" : "auto"),
           selectedFeatureIndexes: [],
           onEdit: ({ updatedData, editType }) => {
             setLassoGeoJson(updatedData);
-            if (editType !== 'addFeature') return;
+            if (editType !== "addFeature") return;
 
             const polyFeature = updatedData.features.at(-1);
             if (!polyFeature) return;
 
             if (
               !polyFeature.geometry ||
-              polyFeature.geometry.type !== 'Polygon' ||
+              polyFeature.geometry.type !== "Polygon" ||
               !Array.isArray((polyFeature.geometry as any).coordinates) ||
               !Array.isArray((polyFeature.geometry as any).coordinates[0]) ||
               (polyFeature.geometry as any).coordinates[0].length < 3
             ) {
-              console.warn('🚫 Lasso polygon missing coordinates – selection skipped');
+              console.warn(
+                "🚫 Lasso polygon missing coordinates – selection skipped",
+              );
               return;
             }
 
             const idsSel: string[] = [];
             filteredPoints.forEach((pt) => {
-              if (booleanPointInPolygon(turfPoint([pt.x, pt.y]), polyFeature.geometry as any)) {
+              if (
+                booleanPointInPolygon(
+                  turfPoint([pt.x, pt.y]),
+                  polyFeature.geometry as any,
+                )
+              ) {
                 idsSel.push(pt.id);
               }
             });
 
             setSelectedIdsStore(idsSel);
-            if (polyFeature.geometry?.type === 'Polygon' && Array.isArray(polyFeature.geometry.coordinates)) {
+            if (
+              polyFeature.geometry?.type === "Polygon" &&
+              Array.isArray(polyFeature.geometry.coordinates)
+            ) {
               // @ts-ignore – coordinates type
               setSelectedPolygonStore(polyFeature.geometry.coordinates[0]);
             }
@@ -762,24 +1040,24 @@ function EnhancedDeckGLVisualization({
             pickable: [lassoMode],
             data: [lassoGeoJson],
           },
-        })
+        }),
       );
     }
 
-    const heatmapActive = overlayMode === 'heatmap' && heatmapVisible;
+    const heatmapActive = overlayMode === "heatmap" && heatmapVisible;
 
     // Scatter layer
     if (showScatter) {
       const enhancedScatterplotLayer = new ScatterplotLayerComponent({
-        id: 'umap-points',
+        id: "umap-points",
         data: filteredPoints,
         pickable: !lassoMode,
         stroked: true,
-        lineWidthUnits: 'pixels',
+        lineWidthUnits: "pixels",
         lineWidthMinPixels: 1,
         getLineColor: [0, 0, 0, 200],
         filled: true,
-        radiusUnits: 'pixels',
+        radiusUnits: "pixels",
         radiusMinPixels: effectivePointSize,
         getPosition: (d) => [d.x, d.y],
         getFillColor: (d) => {
@@ -792,7 +1070,7 @@ function EnhancedDeckGLVisualization({
             clusterStats.totalClusters,
             selectedClusterId ?? null,
             hoveredObject ? hoveredObject.id === d.id : false,
-            effectiveColorPalette
+            effectiveColorPalette,
           );
           // Reduce opacity when heatmap active so density shows through
           if (heatmapActive) {
@@ -800,9 +1078,18 @@ function EnhancedDeckGLVisualization({
           }
           return base;
         },
-        getRadius: (d)=> selectedIds && selectedIds.includes(d.id) ? effectivePointSize*1.6 : effectivePointSize,
+        getRadius: (d) =>
+          selectedIds && selectedIds.includes(d.id)
+            ? effectivePointSize * 1.6
+            : effectivePointSize,
         updateTriggers: {
-          getFillColor: [selectedIds, hoveredObject, selectedClusterId, effectiveColorPalette, heatmapActive],
+          getFillColor: [
+            selectedIds,
+            hoveredObject,
+            selectedClusterId,
+            effectiveColorPalette,
+            heatmapActive,
+          ],
           getRadius: [selectedIds, effectivePointSize],
           pickable: [lassoMode],
         },
@@ -878,11 +1165,12 @@ function EnhancedDeckGLVisualization({
     );
   }
 
-  console.log('🎬 Rendering DeckGL with layers:', layers.length);
-  
+  console.log("🎬 Rendering DeckGL with layers:", layers.length);
+
   return (
-    <DeckGLComponent ref={deckRef}
-      views={new OrthographicView({ id: 'ortho' })}
+    <DeckGLComponent
+      ref={deckRef}
+      views={new OrthographicView({ id: "ortho" })}
       initialViewState={orthoViewState}
       controller={{
         dragPan: true,
@@ -894,37 +1182,38 @@ function EnhancedDeckGLVisualization({
         keyboard: true,
       }}
       layers={layers}
-      style={{ 
-        width: '100%', 
-        height: '100%',
-        position: 'relative'
+      style={{
+        width: "100%",
+        height: "100%",
+        position: "relative",
       }}
       getCursor={({ isDragging, isHovering }) => {
-        if (lassoMode) return 'crosshair';
-        if (isDragging) return 'grabbing';
-        if (isHovering) return 'pointer';
-        return 'grab';
+        if (lassoMode) return "crosshair";
+        if (isDragging) return "grabbing";
+        if (isHovering) return "pointer";
+        return "grab";
       }}
       onViewStateChange={({ viewState }) => {
-        console.log('🔄 Viewport changed:', viewState);
+        console.log("🔄 Viewport changed:", viewState);
       }}
       onLoad={() => {
-        console.log('✅ DeckGL loaded successfully - WebGL context ready');
+        console.log("✅ DeckGL loaded successfully - WebGL context ready");
       }}
       onError={(error) => {
         // deck.gl can sometimes forward non-Error objects – ensure we
         // always log something human readable to aid debugging.
-        const details = error instanceof Error ? error.message : JSON.stringify(error ?? {});
-        console.error('❌ DeckGL error:', details, error);
+        const details =
+          error instanceof Error ? error.message : JSON.stringify(error ?? {});
+        console.error("❌ DeckGL error:", details, error);
       }}
       deviceProps={{
-        type: 'webgl',
+        type: "webgl",
         webgl: {
           antialias: false,
-          powerPreference: 'high-performance',
-          preserveDrawingBuffer: false
-        }
+          powerPreference: "high-performance",
+          preserveDrawingBuffer: false,
+        },
       }}
     />
   );
-} 
+}

--- a/frontend/src/app/logs/[jobId]/page.tsx
+++ b/frontend/src/app/logs/[jobId]/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import {
+  Box,
+  Heading,
+  Text,
+  VStack,
+  HStack,
+  Spinner,
+  Progress,
+  Checkbox,
+  Button,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+} from '@chakra-ui/react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getIngestStatus, archiveExact } from '@/lib/api';
+import { Header } from '@/components/Header';
+
+export default function JobLogsPage({ params }: { params: { jobId: string } }) {
+  const { jobId } = params;
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['job-status', jobId],
+    queryFn: () => getIngestStatus(jobId),
+    refetchInterval: 3000,
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveExact(Array.from(selected)),
+    onSuccess: () => setSelected(new Set()),
+    onSettled: onClose,
+  });
+
+  const toggleSelect = (path: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const handleArchive = () => {
+    archiveMutation.mutate();
+  };
+
+  return (
+    <Box minH="100vh">
+      <Header />
+      <Box p={8} maxW="4xl" mx="auto">
+        <Heading size="lg" mb={4}>
+          Ingestion Job {jobId}
+        </Heading>
+        {isLoading || !data ? (
+          <HStack mt={8}>
+            <Spinner />
+            <Text>Loading job status...</Text>
+          </HStack>
+        ) : (
+          <VStack align="start" spacing={4} w="full">
+            <Text>Status: {data.status}</Text>
+            <Text>{data.message}</Text>
+            <Progress value={data.progress} w="full" />
+            <Box w="full">
+              <Heading size="md" mt={6} mb={2}>
+                Exact Duplicates Found
+              </Heading>
+              {data.exact_duplicates.length === 0 ? (
+                <Text>No duplicates detected.</Text>
+              ) : (
+                <VStack align="start" spacing={2} w="full">
+                  {data.exact_duplicates.map((dup) => (
+                    <HStack key={dup.file_path} justify="space-between" w="full">
+                      <Checkbox
+                        isChecked={selected.has(dup.file_path)}
+                        onChange={() => toggleSelect(dup.file_path)}
+                      >
+                        <Text fontSize="sm" noOfLines={1}>
+                          {dup.file_path}
+                        </Text>
+                      </Checkbox>
+                    </HStack>
+                  ))}
+                  <Button
+                    colorScheme="red"
+                    onClick={onOpen}
+                    isDisabled={selected.size === 0}
+                    isLoading={archiveMutation.isLoading}
+                  >
+                    Archive Selected
+                  </Button>
+                </VStack>
+              )}
+            </Box>
+          </VStack>
+        )}
+      </Box>
+
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Archive Files
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              Are you sure you want to archive {selected.size} file(s)? This will
+              move them to the _VibeDuplicates folder.
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose} mr={3}>
+                Cancel
+              </Button>
+              <Button
+                colorScheme="red"
+                onClick={handleArchive}
+                isLoading={archiveMutation.isLoading}
+              >
+                Archive
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Box>
+  );
+}

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { Box, Heading, Text } from '@chakra-ui/react';
+import { Header } from '@/components/Header';
+
+export default function LogsHome() {
+  return (
+    <Box minH="100vh">
+      <Header />
+      <Box p={8} maxW="3xl" mx="auto">
+        <Heading size="lg" mb={4}>Activity Logs</Heading>
+        <Text>Select an ingestion job to view details.</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,7 +28,7 @@ import {
   Heading,
   Container
 } from '@chakra-ui/react';
-import { FiSearch, FiUpload, FiFolder, FiEye, FiZap, FiShield, FiDatabase } from 'react-icons/fi';
+import { FiSearch, FiUpload, FiFolder, FiEye, FiZap, FiShield, FiDatabase, FiLayers } from 'react-icons/fi';
 import { Header } from '@/components/Header';
 import { CollectionModal } from '@/components/CollectionModal';
 import { AddImagesModal } from '@/components/AddImagesModal';
@@ -149,6 +149,15 @@ function HomeContent() {
       color: 'orange',
       action: () => router.push('/logs'),
       disabled: false,
+      featured: false
+    },
+    {
+      title: 'Duplicate Management',
+      description: 'Find and archive duplicate images',
+      icon: FiLayers,
+      color: 'red',
+      action: () => router.push('/duplicates'),
+      disabled: setupStep < 3,
       featured: false
     },
     {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,127 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8002",
+  timeout: 10000,
+});
+
+export const mlApi = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_ML_API_URL || "http://localhost:8001",
+  timeout: 10000,
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 404) {
+      throw new Error("Resource not found");
+    }
+    if (error.response?.status >= 500) {
+      throw new Error("Server error - please try again later");
+    }
+    throw error;
+  },
+);
+
+export async function ping() {
+  const { data } = await api.get("/health");
+  return data;
+}
+
+export async function getCollections() {
+  const { data } = await api.get("/api/v1/collections");
+  return data as string[];
+}
+
+export async function selectCollection(collectionName: string) {
+  const { data } = await api.post("/api/v1/collections/select", {
+    collection_name: collectionName,
+  });
+  return data;
+}
+
+export async function deleteCollection(collectionName: string) {
+  const { data } = await api.delete(`/api/v1/collections/${collectionName}`);
+  return data;
+}
+
+export interface CollectionInfo {
+  name: string;
+  status: string;
+  points_count: number;
+  vectors_count: number;
+  indexed_vectors_count: number;
+  config: { vector_size?: number; distance?: string };
+  sample_points: any[];
+  is_active: boolean;
+}
+
+export async function getCollectionInfo(
+  collectionName: string,
+): Promise<CollectionInfo> {
+  const { data } = await api.get(`/api/v1/collections/${collectionName}/info`);
+  return data as CollectionInfo;
+}
+
+export async function mergeCollections(dest: string, sources: string[]) {
+  const { data } = await api.post("/api/v1/collections/merge", {
+    dest_collection: dest,
+    source_collections: sources,
+  });
+  return data;
+}
+
+export async function archiveExact(filePaths: string[]) {
+  const { data } = await api.post("/api/v1/duplicates/archive-exact", {
+    file_paths: filePaths,
+  });
+  return data;
+}
+
+export interface FindSimilarTask {
+  task_id: string;
+  status: string;
+  progress: number;
+  total_points: number;
+  processed_points: number;
+  results: any[];
+}
+
+export async function startFindSimilar(
+  threshold: number,
+  limitPerImage: number,
+) {
+  const { data } = await api.post("/api/v1/duplicates/find-similar", {
+    threshold,
+    limit_per_image: limitPerImage,
+  });
+  return data as FindSimilarTask;
+}
+
+export async function getFindSimilarReport(taskId: string) {
+  const { data } = await api.get(`/api/v1/duplicates/report/${taskId}`);
+  return data as FindSimilarTask;
+}
+
+export async function archiveSelection(pointIds: string[]) {
+  const { data } = await api.post("/api/v1/curation/archive-selection", {
+    point_ids: pointIds,
+  });
+  return data;
+}
+
+export interface IngestStatus {
+  status: string;
+  message: string;
+  progress: number;
+  processed_files: number;
+  cached_files: number;
+  total_files: number;
+  logs: string[];
+  exact_duplicates: { file_path: string; existing_id: string }[];
+}
+
+export async function getIngestStatus(jobId: string): Promise<IngestStatus> {
+  const { data } = await api.get(`/api/v1/ingest/status/${jobId}`);
+  return data as IngestStatus;
+}


### PR DESCRIPTION
## Summary
- expose central axios wrapper with helpers for collection and duplicate APIs
- implement `/duplicates` page to run near-duplicate analysis and archive selections
- surface Duplicate Management shortcut on dashboard
- allow committing frontend/src/lib by updating `.gitignore`
- add ingestion report view with archiving
- enable archiving from UMAP selection with confirmation dialogs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685eabf49cb4832c9cf553fb6d0d24c5