### PR TITLE
Restore autosize and fix readiness flag

### DIFF
--- a/backend/ingestion_orchestration_fastapi_app/dependencies.py
+++ b/backend/ingestion_orchestration_fastapi_app/dependencies.py
@@ -2,7 +2,8 @@ from fastapi import Request, HTTPException
 from qdrant_client import QdrantClient
 import os
 
-from .pipeline.manager import PipelineManager
+from typing import Union
+
 from .config import get_settings
 
 # Environment variables for Qdrant connection

--- a/backend/ingestion_orchestration_fastapi_app/main.py
+++ b/backend/ingestion_orchestration_fastapi_app/main.py
@@ -14,7 +14,7 @@ import asyncio
 from .dependencies import app_state, get_qdrant_client
 
 # Dynamic batch-size helper (runs in lifespan → sets env vars before heavy work)
-# from .utils import autosize
+from .utils import autosize
 
 # Routers – imported *after* helper to ensure any module-level constants read the
 # finalised environment variables.
@@ -57,8 +57,10 @@ async def lifespan(app: FastAPI):
     # ------------------------------------------------------------------
     # 0️⃣  Dynamically size batch parameters (RAM-aware)
     # ------------------------------------------------------------------
-    # await autosize.autosize_batches(os.getenv("ML_INFERENCE_SERVICE_URL", "http://localhost:8001"))
-    # app_state.is_ready_for_ingestion = autosize.CAPABILITIES_FETCHED
+    await autosize.autosize_batches(
+        os.getenv("ML_INFERENCE_SERVICE_URL", "http://localhost:8001")
+    )
+    app_state.is_ready_for_ingestion = autosize.CAPABILITIES_FETCHED
     
     # ------------------------------------------------------------------
     # Env-var aliasing – ensure both ML_SERVICE_URL and ML_INFERENCE_SERVICE_URL

--- a/backend/ingestion_orchestration_fastapi_app/utils/autosize.py
+++ b/backend/ingestion_orchestration_fastapi_app/utils/autosize.py
@@ -1,0 +1,35 @@
+import os
+import logging
+import psutil
+import httpx
+
+CAPABILITIES_FETCHED = False
+
+async def autosize_batches(ml_url: str) -> None:
+    """Compute batch sizes based on ML service capability and system RAM."""
+    log = logging.getLogger(__name__)
+    safe_clip = 1
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.get(f"{ml_url}/api/v1/capabilities")
+            r.raise_for_status()
+            safe_clip = int(r.json().get("safe_clip_batch", 1))
+    except Exception as e:
+        log.warning(f"Could not fetch ML capabilities, defaulting to 1: {e}")
+
+    free_ram = psutil.virtual_memory().available
+    ram_batch = int((free_ram * 0.60) / (2 * 1024 * 1024))
+    ram_upsert = int((free_ram * 0.10) / (6 * 1024))
+
+    ml_batch = max(1, min(safe_clip, ram_batch, 2048))
+    qdrant_batch = max(32, min(ram_upsert, 2048))
+
+    os.environ.setdefault("ML_INFERENCE_BATCH_SIZE", str(ml_batch))
+    os.environ.setdefault("QDRANT_UPSERT_BATCH_SIZE", str(qdrant_batch))
+    log.info(
+        "Auto-set ML_INFERENCE_BATCH_SIZE=%s, QDRANT_UPSERT_BATCH_SIZE=%s",
+        ml_batch,
+        qdrant_batch,
+    )
+    global CAPABILITIES_FETCHED
+    CAPABILITIES_FETCHED = True


### PR DESCRIPTION
## Summary
- bring back autosize helper to compute batch sizes on startup
- call `autosize_batches` in `lifespan` so ingestion service becomes ready
- clean up dependencies module import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cupy')*


------
https://chatgpt.com/codex/tasks/task_e_686fcff28d9c832c82596f29d57b116b