### PR TITLE
Add GPU job scheduler service

### DIFF
--- a/backend/ml_inference_fastapi_app/services/gpu_job_scheduler.py
+++ b/backend/ml_inference_fastapi_app/services/gpu_job_scheduler.py
@@ -1,0 +1,111 @@
+import asyncio
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Coroutine, Dict, List
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the coroutine that will process a batch of items
+BatchProcFn = Callable[[List[Any]], Coroutine[Any, Any, List[Any]]]
+
+@dataclass
+class GPUJob:
+    """Representation of a GPU job request."""
+
+    job_id: str
+    batch: List[Any]
+    func: BatchProcFn
+    est_vram: int  # bytes required to process the batch
+
+
+# --- Internal Queues and State ---
+_job_queue: asyncio.Queue[GPUJob] = asyncio.Queue()
+_job_results: Dict[str, List[Any]] = {}
+_job_expected: Dict[str, int] = {}
+_job_events: Dict[str, asyncio.Event] = {}
+
+_WORKERS_STARTED = False
+_WORKER_COUNT = int(os.environ.get("GPU_SCHEDULER_WORKERS", "1"))
+
+
+def _ensure_workers_started() -> None:
+    global _WORKERS_STARTED
+    if _WORKERS_STARTED:
+        return
+    loop = asyncio.get_event_loop()
+    for _ in range(_WORKER_COUNT):
+        loop.create_task(_gpu_worker())
+    _WORKERS_STARTED = True
+    logger.info("GPU job scheduler started with %d worker(s)", _WORKER_COUNT)
+
+
+async def _gpu_worker() -> None:
+    """Background worker that executes jobs when enough GPU memory is available."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    while True:
+        job = await _job_queue.get()
+        try:
+            await _process_job(job, device)
+        except Exception as e:
+            logger.error("Job %s failed: %s", job.job_id, e, exc_info=True)
+            _record_result(job.job_id, [], len(job.batch))
+        finally:
+            _job_queue.task_done()
+
+
+async def _process_job(job: GPUJob, device: torch.device) -> None:
+    free_mem, _ = torch.cuda.mem_get_info(device) if device.type == "cuda" else (float("inf"), float("inf"))
+    if job.est_vram <= free_mem:
+        logger.debug("Running job %s with batch size %d", job.job_id, len(job.batch))
+        result = await job.func(job.batch)
+        _record_result(job.job_id, result, len(job.batch))
+    else:
+        if len(job.batch) <= 1:
+            # Not enough memory even for a single item, wait and requeue
+            logger.debug("Insufficient VRAM for single-item job %s, retrying", job.job_id)
+            await asyncio.sleep(1)
+            await _job_queue.put(job)
+            return
+        mid = len(job.batch) // 2
+        est = max(1, job.est_vram // 2)
+        logger.debug(
+            "Splitting job %s into two batches of %d and %d due to VRAM limits",
+            job.job_id,
+            mid,
+            len(job.batch) - mid,
+        )
+        await _job_queue.put(GPUJob(job.job_id, job.batch[:mid], job.func, est))
+        await _job_queue.put(GPUJob(job.job_id, job.batch[mid:], job.func, est))
+
+
+def _record_result(job_id: str, part: List[Any], count: int) -> None:
+    results = _job_results.setdefault(job_id, [])
+    results.extend(part)
+    _job_expected[job_id] -= count
+    if _job_expected[job_id] <= 0:
+        _job_events[job_id].set()
+
+
+# --- Public API ---
+async def enqueue_job(batch: List[Any], func: BatchProcFn, est_vram: int) -> str:
+    """Add a new GPU job to the queue and return its job_id."""
+    _ensure_workers_started()
+    job_id = str(uuid.uuid4())
+    _job_expected[job_id] = len(batch)
+    _job_events[job_id] = asyncio.Event()
+    await _job_queue.put(GPUJob(job_id, batch, func, est_vram))
+    return job_id
+
+
+async def get_job_result(job_id: str) -> List[Any]:
+    """Wait for a job to finish and return its aggregated results."""
+    event = _job_events.get(job_id)
+    if not event:
+        return []
+    await event.wait()
+    return _job_results.pop(job_id, [])
+

--- a/components/task_orchestrator.py
+++ b/components/task_orchestrator.py
@@ -1,0 +1,43 @@
+import threading
+from typing import Callable, Any, Dict
+
+class TaskOrchestrator:
+    """Simple thread-based orchestrator to run named tasks sequentially."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tasks: Dict[str, threading.Thread] = {}
+
+    def submit(self, name: str, func: Callable[..., Any], *args: Any) -> bool:
+        """Submit a task if not already running."""
+        with self._lock:
+            if name in self._tasks and self._tasks[name].is_alive():
+                return False
+            thread = threading.Thread(target=self._run, args=(name, func, args))
+            thread.start()
+            self._tasks[name] = thread
+            return True
+
+    def _run(self, name: str, func: Callable[..., Any], args: tuple) -> None:
+        try:
+            func(*args)
+        finally:
+            with self._lock:
+                self._tasks.pop(name, None)
+
+    def is_running(self, name: str) -> bool:
+        with self._lock:
+            t = self._tasks.get(name)
+            return t.is_alive() if t else False
+
+
+_global_orchestrator = TaskOrchestrator()
+
+
+def submit(name: str, func: Callable[..., Any], *args: Any) -> bool:
+    return _global_orchestrator.submit(name, func, *args)
+
+
+def is_running(name: str) -> bool:
+    return _global_orchestrator.is_running(name)
+


### PR DESCRIPTION
## Summary
- add GPU job scheduler implementation for ML inference
- provide minimal `TaskOrchestrator` so tests can import it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for cupy and torch)*

------
https://chatgpt.com/codex/tasks/task_e_687636827064832c8088c691c9442462