### PR TITLE
Implement caption toggle and progressive loading

### DIFF
--- a/backend/ingestion_orchestration_fastapi_app/routers/collections.py
+++ b/backend/ingestion_orchestration_fastapi_app/routers/collections.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from typing import List, Dict, Any
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient, models as qdr
-from qdrant_client.http.models import Distance, VectorParams
+from qdrant_client.http.models import Distance, VectorParams, HnswConfigDiff
 import logging
 
 from ..dependencies import get_qdrant_client, app_state
@@ -112,7 +112,8 @@ async def create_collection(req: CreateCollectionRequest, qdrant: QdrantClient =
 
     qdrant.create_collection(
         collection_name=req.collection_name,
-        vectors_config=VectorParams(size=req.vector_size, distance=dist_enum)
+        vectors_config=VectorParams(size=req.vector_size, distance=dist_enum, on_disk=True),
+        hnsw_config=HnswConfigDiff(on_disk=True)
     )
     return {"status": "success", "collection": req.collection_name}
 
@@ -143,7 +144,8 @@ async def create_collection_from_selection(
     # 3) Create destination collection with the same vector size / distance
     qdrant.create_collection(
         collection_name=req.new_collection_name,
-        vectors_config=VectorParams(size=vec_params.size, distance=vec_params.distance)
+        vectors_config=VectorParams(size=vec_params.size, distance=vec_params.distance, on_disk=True),
+        hnsw_config=HnswConfigDiff(on_disk=True)
     )
 
     # 4) Retrieve the selected points (vectors + payload) in batches to avoid URL length limits

--- a/backend/ingestion_orchestration_fastapi_app/routers/ingest.py
+++ b/backend/ingestion_orchestration_fastapi_app/routers/ingest.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, File, UploadFile
+from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, File, UploadFile, Query
 from pydantic import BaseModel, Field
 from typing import Dict, Any, List
 import logging
@@ -105,7 +105,8 @@ async def start_ingestion(
     request: IngestRequest,
     background_tasks: BackgroundTasks,
     qdrant_client: QdrantClient = Depends(get_qdrant_client),
-    collection_name: str = Depends(get_active_collection)
+    collection_name: str = Depends(get_active_collection),
+    caption: bool = Query(True, description="Generate captions during ingestion"),
 ):
     """
     Starts a background ingestion job for a local directory path.
@@ -121,6 +122,7 @@ async def start_ingestion(
         collection_name=collection_name,
         background_tasks=background_tasks,
         qdrant_client=qdrant_client,
+        caption=caption,
     )
     return JobResponse(job_id=job_id, status="started", message="Ingestion job started successfully.")
 
@@ -129,7 +131,8 @@ async def start_ingestion_from_path(
     request: IngestRequest,
     background_tasks: BackgroundTasks,
     qdrant_client: QdrantClient = Depends(get_qdrant_client),
-    collection_name: str = Depends(get_active_collection)
+    collection_name: str = Depends(get_active_collection),
+    caption: bool = Query(True, description="Generate captions during ingestion"),
 ):
     """
     Alias for the main ingestion endpoint. Starts a background ingestion job for a given path.
@@ -143,6 +146,7 @@ async def start_ingestion_from_path(
         collection_name=collection_name,
         background_tasks=background_tasks,
         qdrant_client=qdrant_client,
+        caption=caption,
     )
     return JobResponse(job_id=job_id, status="started", message="Ingestion scan started successfully.")
 
@@ -156,7 +160,8 @@ async def upload_and_ingest_files(
     background_tasks: BackgroundTasks,
     files: List[UploadFile] = File(...),
     qdrant_client: QdrantClient = Depends(get_qdrant_client),
-    collection_name: str = Depends(get_active_collection)
+    collection_name: str = Depends(get_active_collection),
+    caption: bool = Query(True, description="Generate captions during ingestion"),
 ):
     """
     Accepts file uploads, saves them to a temporary directory,
@@ -185,7 +190,8 @@ async def upload_and_ingest_files(
         directory_path=temp_dir,
         collection_name=collection_name,
         background_tasks=background_tasks,
-        qdrant_client=qdrant_client
+        qdrant_client=qdrant_client,
+        caption=caption,
     )
     
     # The cleanup will be handled by the background task associated with the request that started the pipeline

--- a/frontend/src/app/latent-space/page.tsx
+++ b/frontend/src/app/latent-space/page.tsx
@@ -29,7 +29,7 @@ import { UMAPScatterPlot } from './components/UMAPScatterPlot';
 import { ClusteringControls } from './components/ClusteringControls';
 import { ThumbnailOverlay } from './components/ThumbnailOverlay';
 import { StatsBar } from './components/StatsBar';
-import { useUMAP } from './hooks/useUMAP';
+import { useUMAP, useUMAPZoom, fetchUMAPProjection } from './hooks/useUMAP';
 import { useStore } from '@/store/useStore';
 import { useLatentSpaceStore } from './hooks/useLatentSpaceStore';
 import { UMAPPoint } from './types/latent-space';
@@ -110,8 +110,19 @@ export default function LatentSpacePage() {
     onSettled: onClose,
   });
 
+  const loadAllMutation = useMutation({
+    mutationFn: () => fetchUMAPProjection(collection, 5000, undefined, true),
+    onSuccess: (data) => {
+      useLatentSpaceStore.getState().setProjectionData(data);
+    },
+  });
+
   const handleArchive = () => {
     archiveMutation.mutate(Array.from(selectedIds));
+  };
+
+  const handleLoadAll = () => {
+    loadAllMutation.mutate();
   };
 
   const debugInfo = {
@@ -368,6 +379,9 @@ export default function LatentSpacePage() {
               stats={effectiveProjection.clustering_info}
               totalPoints={effectiveProjection.points.length}
             />
+            <Button size="sm" onClick={handleLoadAll} alignSelf="start">
+              Load all points
+            </Button>
 
             {/* Cluster Labeling Panel */}
             <ClusterLabelingPanel

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ python-dateutil==2.9.0.post0
 pytz==2025.1
 PyYAML==6.0.2
 qdrant-client==1.13.3
+requests>=2.32.0
 rawpy==0.24.0
 referencing==0.36.2
 regex==2024.11.6


### PR DESCRIPTION
## Summary
- allow inference service to disable captions via query param
- add caption flag to ingestion endpoints and pipeline manager
- create Qdrant collections with on-disk vectors
- expose full/bbox params in UMAP projection endpoint
- add helper hook `useUMAPZoom` and load-all button
- disable Qdrant indexing during ingestion and re-enable afterwards
- add basic bounds checks to `/umap/projection`

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: psutil, fastapi, matplotlib, PIL)*


------
https://chatgpt.com/codex/tasks/task_e_68821171fdf8832c8cdb426e8e4ed081