### PR TITLE
Optimize timeline complexity calculations

### DIFF
--- a/tools/dev-graph-ui/src/app/dev-graph/components/EnhancedTimelineView.tsx
+++ b/tools/dev-graph-ui/src/app/dev-graph/components/EnhancedTimelineView.tsx
@@ -97,29 +97,43 @@ export function EnhancedTimelineView({
       ctx.stroke();
     }
 
+    // Build prefix arrays for cumulative metrics
+    const commitPrefixes: number[] = [];
+    const filePrefixes: number[] = [];
+    let commitSum = 0;
+    let fileSum = 0;
+    buckets.forEach((b, i) => {
+      commitSum += b.commit_count;
+      fileSum += b.file_changes;
+      commitPrefixes[i] = commitSum;
+      filePrefixes[i] = fileSum;
+    });
+
     // Draw bars based on mode
     buckets.forEach((bucket, index) => {
       const x = padding + (chartWidth / buckets.length) * index;
       const barWidth = (chartWidth / buckets.length) * 0.8;
-      
+
+      let barHeight: number;
+
       if (showComplexity) {
         // Graph complexity visualization - simulate growing complexity over time
-        const cumulativeCommits = buckets.slice(0, index + 1).reduce((sum, b) => sum + b.commit_count, 0);
-        const cumulativeFiles = buckets.slice(0, index + 1).reduce((sum, b) => sum + b.file_changes, 0);
-        
+        const cumulativeCommits = commitPrefixes[index];
+        const cumulativeFiles = filePrefixes[index];
+
         // Simulate graph complexity as a function of cumulative activity
         const complexity = Math.min(100, Math.sqrt(cumulativeCommits * 0.1 + cumulativeFiles * 0.05));
-        const barHeight = (complexity / 100) * chartHeight;
-        
+        barHeight = (complexity / 100) * chartHeight;
+
         // Color based on complexity level
         const intensity = complexity / 100;
         const color = intensity > 0.7 ? `rgba(168, 85, 247, ${0.4 + intensity * 0.6})` : // purple for high complexity
                      intensity > 0.4 ? `rgba(59, 130, 246, ${0.4 + intensity * 0.6})` : // blue for medium
                      `rgba(34, 197, 94, ${0.4 + intensity * 0.6})`; // green for low
-        
+
         ctx.fillStyle = color;
         ctx.fillRect(x, padding + chartHeight - barHeight, barWidth, barHeight);
-        
+
         // Draw complexity indicator dots
         const dotCount = Math.min(5, Math.floor(complexity / 20));
         for (let i = 0; i < dotCount; i++) {
@@ -131,26 +145,20 @@ export function EnhancedTimelineView({
         }
       } else {
         // Traditional commit count visualization
-        const barHeight = (bucket.commit_count / maxCommits) * chartHeight;
-        
+        barHeight = (bucket.commit_count / maxCommits) * chartHeight;
+
         // Color based on commit count
         const intensity = bucket.commit_count / maxCommits;
         const color = `rgba(59, 130, 246, ${0.3 + intensity * 0.7})`; // blue with varying opacity
-        
+
         ctx.fillStyle = color;
         ctx.fillRect(x, padding + chartHeight - barHeight, barWidth, barHeight);
       }
-      
+
       // Draw border
       ctx.strokeStyle = accentColor;
       ctx.lineWidth = 1;
-      ctx.strokeRect(x, padding + chartHeight - (showComplexity ? 
-        (Math.min(100, Math.sqrt(buckets.slice(0, index + 1).reduce((sum, b) => sum + b.commit_count, 0) * 0.1 + buckets.slice(0, index + 1).reduce((sum, b) => sum + b.file_changes, 0) * 0.05)) / 100) * chartHeight :
-        (bucket.commit_count / maxCommits) * chartHeight
-      ), barWidth, showComplexity ? 
-        (Math.min(100, Math.sqrt(buckets.slice(0, index + 1).reduce((sum, b) => sum + b.commit_count, 0) * 0.1 + buckets.slice(0, index + 1).reduce((sum, b) => sum + b.file_changes, 0) * 0.05)) / 100) * chartHeight :
-        (bucket.commit_count / maxCommits) * chartHeight
-      );
+      ctx.strokeRect(x, padding + chartHeight - barHeight, barWidth, barHeight);
     });
 
     // Draw selection range


### PR DESCRIPTION
## Summary
- precompute prefix sums for commits and file changes in EnhancedTimelineView
- use prefix arrays and cached bar heights instead of repeated slice/reduce operations

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to patch lockfile: fetch failed ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68c7d1601070832c95e8c9af8e13b022