### PR TITLE
feat: improve skill scores for Pixel Detective

### DIFF
--- a/skills/dev-graph-exports/SKILL.md
+++ b/skills/dev-graph-exports/SKILL.md
@@ -1,74 +1,86 @@
 ---
 name: dev-graph-exports
-description: Export Dev Graph UI assets and dashboard data. Use when the user asks for structure SVG exports, timeline SVG/MP4 exports, per-commit SVGs, sprint-linked visuals, or dashboard/analytics JSON from the Dev Graph API.
+description: "Export Dev Graph UI assets and dashboard data. Use when the user asks for structure SVG exports, timeline SVG/MP4 exports, per-commit SVGs, sprint-linked visuals, or dashboard/analytics JSON from the Dev Graph API."
 ---
 
 # Dev Graph Exports
 
-Generate exportable assets that match the Dev Graph UI.
+Generate exportable assets that match the Dev Graph UI: structure SVGs, timeline animations, per-commit frames, and dashboard JSON.
 
 ## Quickstart
-- API-only SVG-parity timeline exports: `node skills/dev-graph-exports/scripts/export_timeline_segments_svg_parity.js --api http://localhost:8080`
-- Dashboard JSON export: `python skills/dev-graph-exports/scripts/export_dashboard_data.py --base-url http://localhost:8080`
+
+```bash
+# Timeline SVG-parity export (API only, no UI required)
+node skills/dev-graph-exports/scripts/export_timeline_segments_svg_parity.js --api http://localhost:8080
+
+# Dashboard JSON export
+python skills/dev-graph-exports/scripts/export_dashboard_data.py --base-url http://localhost:8080
+```
 
 ## Requirements
+
 - Dev Graph API running on `http://localhost:8080`
-- Node.js 18+ available (for SVG-parity renderer; uses global `fetch`)
-- Dependencies installed in `tools/dev-graph-ui`:
-  - `npm --prefix tools/dev-graph-ui install jsdom @resvg/resvg-js`
-- ffmpeg available on PATH for mp4/gif exports
+- Node.js 18+ (for SVG-parity renderer; uses global `fetch`)
+- Dependencies: `npm --prefix tools/dev-graph-ui install jsdom @resvg/resvg-js`
+- ffmpeg on PATH (for MP4/GIF exports)
+
+## Workflow
+
+1. **Pre-flight** — Verify the Dev Graph API is reachable: `curl -s http://localhost:8080/docs | head -1`
+2. **Export** — Run the appropriate script (see Exports below).
+3. **Verify** — Check that output files exist and are non-empty:
+   ```bash
+   ls -lh exports/dev-graph/
+   ```
 
 ## Exports
 
-### Structure SVG (UI export)
-- Script: `python skills/dev-graph-exports/scripts/export_structure_svg.py`
-- Output default: `exports/dev-graph/structure-graph.svg`
-- Optional: `--url http://localhost:3001/dev-graph/structure --output <path>`
-- Filters: `--source-type File --target-type Document --relation-type CONTAINS_CHUNK --max-nodes 250`
+### Structure SVG
+
+```bash
+python skills/dev-graph-exports/scripts/export_structure_svg.py \
+  --url http://localhost:3001/dev-graph/structure \
+  --output exports/dev-graph/structure-graph.svg
+```
+
+Optional filters: `--source-type File --target-type Document --relation-type CONTAINS_CHUNK --max-nodes 250`
 
 ### Timeline MP4 + GIF segments (SVG-parity, API only)
-- Script: `node skills/dev-graph-exports/scripts/export_timeline_segments_svg_parity.js`
-- Output default: mp4 + gif plus per-commit SVG frames under `exports/dev-graph/timeline-frames/`
-- The SVG frames are the primary artifacts; raster frames are temporary and removed after encoding.
-- Segments: commits 1-70, 70-200, 200+.
-- Key options:
-  - Range: `--range-start 0 --range-end 69` (single segment)
-  - Segments: `--segments "0-69,69-199,199-"` (dash with empty end means "to last")
-  - Sprint window preset: `--sprint sprint-11` (uses `/api/v1/dev-graph/sprints/<n>` start/end)
-  - Single SVG frame (no ffmpeg): `--frame-only true --sprint sprint-11 --sprint-frame end --frame-output docs/sprints/sprint-11/_dev_graph_visuals/timeline.svg`
-  - Single SVG at commit: `--frame-only true --frame-commit abcd123 --frame-output exports/dev-graph/timeline-frame.svg`
-  - Graph density: `--max-nodes 0` (default, no limit)
-  - Node layout: `--show-folder-groups true|false`, `--focused-view true|false`, `--size-by-loc true|false`
-  - Styling: `--color-mode folder|type|commit-flow|activity|none`, `--highlight-docs true|false`, `--edge-emphasis 0.0-1.0`
-  - Filtering: `--active-folders "backend,frontend"`, `--include-patterns "docs,/\\.md$/"`
-  - Canvas size: `--width 1200 --height 600`
-  - Auto-fit (zoom out to see full shape): `--auto-fit true` (default) and `--auto-fit-padding 80`
-  - Auto-fit motion (smooth zoom between frames): `--auto-fit-motion true` (default), `--auto-fit-motion-alpha 0.25`
-  - Focus around a commit: `--focus-commit 120 --focus-window 10` (index) or `--focus-commit abcd123 --focus-window 12` (hash prefix)
-  - Relaxation (cinematic settling): `--relax-ticks-min 180 --relax-ticks-max 520 --relax-ticks-factor 35`
-  - Data volume: `--limit 5000 --max-files 0` (0 means no limit; lets backend return full file lists)
-  - Include every file node: `--include-all-files true` (default)
-  - Downscale on failure: `--downscale-on-fail true` (default), `--downscale-factor 0.85 --downscale-retries 3`
 
-### Per-commit SVG frames
-- Script: `python skills/dev-graph-exports/scripts/export_timeline_svgs.py`
-- Output default: `exports/dev-graph/timeline-frames/`
-- Optional: `--start 0 --count 20`
-- Note: this script is UI-driven (requires the Dev Graph UI running) and requires Python Playwright.
+```bash
+node skills/dev-graph-exports/scripts/export_timeline_segments_svg_parity.js --api http://localhost:8080
+```
+
+Output: MP4 + GIF plus per-commit SVG frames under `exports/dev-graph/timeline-frames/`. Segments default to commits 1–70, 70–200, 200+.
+
+Common options:
+- Single segment: `--range-start 0 --range-end 69`
+- Sprint window: `--sprint sprint-11`
+- Single SVG frame: `--frame-only true --sprint sprint-11 --sprint-frame end --frame-output <path>`
+- Canvas size: `--width 1200 --height 600`
+
+For the full list of layout, styling, filtering, and animation options, run `node skills/dev-graph-exports/scripts/export_timeline_segments_svg_parity.js --help` or see the script header comments.
+
+### Per-commit SVG frames (UI-driven)
+
+```bash
+python skills/dev-graph-exports/scripts/export_timeline_svgs.py --start 0 --count 20
+```
+
+Output: `exports/dev-graph/timeline-frames/`. Requires the Dev Graph UI running and Python Playwright.
 
 ### Dashboard data
-- Script: `python skills/dev-graph-exports/scripts/export_dashboard_data.py`
-- Output default: `exports/dev-graph/dashboard/`
+
+```bash
+python skills/dev-graph-exports/scripts/export_dashboard_data.py --base-url http://localhost:8080
+```
+
+Output: `exports/dev-graph/dashboard/`. Pulls from `/api/v1/dev-graph/stats`, `/analytics`, `/quality`, and `/data-quality/overview`.
 
 ## Notes
-- Timeline exports must use the SVG timeline renderer, not the GL2 timeline view.
-- The SVG-parity exporter uses the Dev Graph API only; UI is not required.
-- Structure export is taken from the main Structure View canvas and reflects current filters.
-- Dashboard exports pull from `/api/v1/dev-graph/stats`, `/analytics`, `/quality`, and `/data-quality/overview`.
-- Use `sprints.json` from dashboard exports to link frames and videos to sprint windows.
-- Defaults aim for full-fidelity output; if a segment fails, it will retry at a smaller canvas size.
 
-## Other scripts (optional)
-- UI-driven structure SVG export: `python skills/dev-graph-exports/scripts/export_structure_svg.py` (requires the UI + Python Playwright)
-- UI-driven MP4 export via the Timeline page: `python skills/dev-graph-exports/scripts/export_timeline_mp4.py` (requires the UI + Python Playwright)
-- Legacy standalone timeline export (non-parity): `python skills/dev-graph-exports/scripts/export_timeline_segments_standalone.py` (requires `matplotlib` + ffmpeg)
+- Timeline exports use the SVG renderer, not the GL2 timeline view.
+- The SVG-parity exporter uses the API only; the UI is not required.
+- Structure export reflects current filters from the Structure View canvas.
+- Use `sprints.json` from dashboard exports to link frames/videos to sprint windows.
+- If a segment fails, it retries at a smaller canvas size (`--downscale-on-fail true` by default).

--- a/skills/rituals-guide/SKILL.md
+++ b/skills/rituals-guide/SKILL.md
@@ -1,27 +1,46 @@
 ---
 name: rituals-guide
-description: Audit and scaffold sprint documentation rituals based on MANIFESTO.md. Use when the user wants to follow the research -> spec -> prompt -> implement -> document workflow, generate checklists/templates, or evaluate documentation quality for a sprint.
+description: "Audit and scaffold sprint documentation rituals based on MANIFESTO.md. Use when the user asks for sprint doc review, documentation audit, ritual scaffolding, sprint checklists, doc quality evaluation, or wants to follow the research -> spec -> prompt -> implement -> document workflow."
 ---
 
 # Rituals Guide
 
-This skill turns the lessons in `MANIFESTO.md` into a practical workflow:
-1) audit an existing sprint folder and its linked evidence, then
-2) scaffold missing docs/templates to follow the same rituals consistently.
+Turn the lessons in `MANIFESTO.md` into a practical workflow: audit an existing sprint folder against the manifesto-derived rubric, then scaffold missing docs and templates to follow the same rituals consistently.
 
 ## Quickstart
-- Audit + generate perspectives: `python skills/rituals-guide/scripts/audit_and_scaffold_rituals.py --sprint sprint-11`
-- Audit + scaffold missing templates: `python skills/rituals-guide/scripts/audit_and_scaffold_rituals.py --sprint sprint-11 --scaffold`
+
+```bash
+# Audit a sprint and generate perspectives
+python skills/rituals-guide/scripts/audit_and_scaffold_rituals.py --sprint sprint-11
+
+# Audit and scaffold missing templates
+python skills/rituals-guide/scripts/audit_and_scaffold_rituals.py --sprint sprint-11 --scaffold
+```
+
+## Workflow
+
+1. **Audit** — Run the script with `--sprint <name>`. It checks the sprint folder against the rubric from [`MANIFESTO.md`](../../MANIFESTO.md) and [`manifesto-derived-rules.md`](../../docs/reference_guides/manifesto-derived-rules.md).
+2. **Review** — Open the generated `RITUAL_AUDIT.md` and check which rituals passed or failed. Each finding links back to the manifesto rule it derives from.
+3. **Scaffold** — Re-run with `--scaffold` to generate missing templates for failing rituals.
+4. **Re-audit** — Run the audit again to confirm fixes. Repeat until all rituals pass.
 
 ## Outputs (per sprint folder)
-- `docs/sprints/<sprint>/RITUAL_AUDIT.md`
-- (Calls sprint perspectives generator) `docs/sprints/<sprint>/PERSPECTIVES.md` + `docs/sprints/<sprint>/_linked_docs.json`
-- Optional scaffolds (only when `--scaffold`):
-  - `docs/sprints/<sprint>/RESEARCH_BRIEF.md`
-  - `docs/sprints/<sprint>/PROMPT_PACK.md`
-  - `docs/sprints/<sprint>/ACCEPTANCE_CHECKS.md`
+
+| File | Generated when |
+|------|---------------|
+| `docs/sprints/<sprint>/RITUAL_AUDIT.md` | Always |
+| `docs/sprints/<sprint>/PERSPECTIVES.md` | Always (calls sprint perspectives generator) |
+| `docs/sprints/<sprint>/_linked_docs.json` | Always |
+| `docs/sprints/<sprint>/RESEARCH_BRIEF.md` | `--scaffold` only |
+| `docs/sprints/<sprint>/PROMPT_PACK.md` | `--scaffold` only |
+| `docs/sprints/<sprint>/ACCEPTANCE_CHECKS.md` | `--scaffold` only |
+
+## Error handling
+
+- If the sprint folder does not exist under `docs/sprints/`, the script exits with an error. Create the folder first or check the sprint name.
+- If `MANIFESTO.md` is missing at the repo root, the audit cannot run. Ensure the file is present.
 
 ## Notes
+
 - Uses existing sprint docs as anchors; no new sprint metadata required.
 - The audit rubric is derived from `MANIFESTO.md` and `docs/reference_guides/manifesto-derived-rules.md`.
-

--- a/skills/sprint-summary-pdf/SKILL.md
+++ b/skills/sprint-summary-pdf/SKILL.md
@@ -1,65 +1,65 @@
 ---
 name: sprint-summary-pdf
-description: Generate per-sprint PDF summaries with a card layout from docs/sprints. Use when the user asks for sprint summaries, sprint recap PDFs, shareable sprint story cards, or to drop PDFs into each sprint folder.
+description: "Generate per-sprint PDF summaries with a card layout from docs/sprints. Use when the user asks for sprint summaries, sprint recap PDFs, shareable sprint story cards, print-ready sprint reports, or to drop PDFs into each sprint folder."
 ---
 
 # Sprint Summary PDF
 
-Use this skill to generate a clean PDF per sprint, saved inside each sprint folder.
+Generate a clean, card-layout PDF per sprint saved inside each sprint folder.
 
 ## Quickstart
-- All sprints (default): `python skills/sprint-summary-pdf/scripts/generate_sprint_summary_pdf.py`
-- Single sprint: `python skills/sprint-summary-pdf/scripts/generate_sprint_summary_pdf.py --sprint sprint-11`
+
+```bash
+# All sprints
+python skills/sprint-summary-pdf/scripts/generate_sprint_summary_pdf.py
+
+# Single sprint
+python skills/sprint-summary-pdf/scripts/generate_sprint_summary_pdf.py --sprint sprint-11
+```
+
+## Workflow
+
+1. **Run the script** targeting one sprint or all sprints.
+2. **Verify output** — Confirm the PDF exists in the sprint folder:
+   ```bash
+   ls docs/sprints/sprint-11/SPRINT_SUMMARY_CARDS.pdf
+   ```
+3. **Review** — Open the PDF and check that cards render correctly with the expected content.
 
 ## Inputs
+
+Each sprint folder is scanned for:
 - `docs/sprints/*/README.md`
 - `docs/sprints/*/PRD.md`
-- `docs/sprints/*/*SUMMARY*.md`
-- `docs/sprints/*/completion-summary*.md`
+- `docs/sprints/*/*SUMMARY*.md` / `completion-summary*.md`
 - `docs/sprints/*/mindmap*.md`
 
 ## Output
-- Default filename: `SPRINT_SUMMARY_CARDS.pdf`
-- Save inside each sprint folder, for example:
-  - `docs/sprints/sprint-11/SPRINT_SUMMARY_CARDS.pdf`
+
+- Filename: `SPRINT_SUMMARY_CARDS.pdf` inside each sprint folder (e.g. `docs/sprints/sprint-11/SPRINT_SUMMARY_CARDS.pdf`).
 
 ## Content extraction
-For each sprint folder, extract:
-- Title and sprint name
-- Dates or time window (if present)
-- Goal or theme (from README or PRD)
-- Key wins or delivered features
-- Risks or known gaps
-- Next steps or transition notes
-- Metrics or performance highlights (if present)
 
-If a sprint is missing a summary file, synthesize a short summary from README and PRD only.
+For each sprint, the script extracts: title, dates/time window, goal/theme (from README or PRD), key wins, risks/gaps, next steps, and metrics. If a sprint lacks a summary file, a short summary is synthesized from README and PRD.
 
 ## Layout and style
-- Use a grid of cards (4 to 6 cards per sprint).
-- Visual tone inspired by the Pixel Detective frontend:
-  - dark base, high contrast text
-  - cyan or teal accent lines
-  - rounded cards, subtle shadows
-  - bold section headers
-- Keep it readable at a glance. Each card should be 3 to 6 bullets.
-- Include a small header with sprint name, status, and dates.
 
-## PDF generation approach
-- Build a single HTML per sprint with inline CSS.
-- Render to PDF using WeasyPrint when available; otherwise leave HTML for manual export.
-- Do not depend on running services.
+- Grid of 4–6 cards per sprint, each card 3–6 bullets.
+- Dark base with high-contrast text, cyan/teal accent lines, rounded cards, subtle shadows.
+- Template: [`assets/sprint_cards_template.html`](assets/sprint_cards_template.html).
 
-## Scope control
-- If user asks for a single sprint, only generate that sprint PDF.
-- If user asks for all, iterate every sprint folder under `docs/sprints/`.
+## PDF generation
 
-## Template and script
-- Template: `skills/sprint-summary-pdf/assets/sprint_cards_template.html`
-- Script: `python skills/sprint-summary-pdf/scripts/generate_sprint_summary_pdf.py` (defaults to `--all`)
-- Single sprint: `--sprint sprint-11`
+- Builds a single HTML per sprint with inline CSS, then renders via WeasyPrint.
+- If WeasyPrint is not installed (`pip install weasyprint`), the HTML is left for manual export.
+- Does not depend on running services.
+
+## Error handling
+
+- If WeasyPrint is missing, the script generates HTML only and logs a warning. Install with `pip install weasyprint`.
+- If a sprint folder contains no recognizable docs, that sprint is skipped with a warning.
 
 ## Notes
-- If a sprint folder has no bullet lists, generate a single Summary card using the first paragraph of README/PRD.
-- Prefer README for narrative, PRD for goals, and completion summaries for wins and gaps.
-- Keep cards concise; trim long bullets and drop low-signal items.
+
+- Prefer README for narrative, PRD for goals, completion summaries for wins and gaps.
+- Keep cards concise; long bullets are trimmed and low-signal items dropped.

--- a/skills/start-dev-graph/SKILL.md
+++ b/skills/start-dev-graph/SKILL.md
@@ -1,70 +1,62 @@
 ---
 name: start-dev-graph
-description: Start, stop, or check Dev Graph services on this machine. Use when the user asks to start Dev Graph, start backend only, start full stack, restart, stop, or check Docker, Neo4j, API, or UI status, or to provide a specific Dev Graph page URL.
+description: "Start, stop, or check Dev Graph services on this machine. Use when the user asks to start Dev Graph, launch backend only, start full stack, restart, stop, or check Docker, Neo4j, API, or UI status, or to provide a specific Dev Graph page URL."
 ---
 
 # Start Dev Graph
 
-Use this skill to run Dev Graph locally with the right subset of services.
+Run Dev Graph locally with the right subset of services.
 
 ## Quickstart
-- Full stack: `powershell -ExecutionPolicy Bypass -File skills\\start-dev-graph\\scripts\\start_dev_graph.ps1 -Mode full`
-- Backend only: `powershell -ExecutionPolicy Bypass -File skills\\start-dev-graph\\scripts\\start_dev_graph.ps1 -Mode backend`
+
+```bash
+# Full stack (Neo4j + API + UI)
+powershell -ExecutionPolicy Bypass -File skills\start-dev-graph\scripts\start_dev_graph.ps1 -Mode full
+
+# Backend only (Neo4j + API)
+powershell -ExecutionPolicy Bypass -File skills\start-dev-graph\scripts\start_dev_graph.ps1 -Mode backend
+
+# Frontend + open browser
+powershell -ExecutionPolicy Bypass -File skills\start-dev-graph\scripts\start_dev_graph.ps1 -Mode frontend -Open -Page /dev-graph/structure
+```
+
+Note: `-Open` is required to open a browser; `-Page` alone will not open anything.
 
 ## Workflow
 
-1. Confirm repo root
-- Require `developer_graph/api.py` and `start_dev_graph.ps1`.
-- If missing, stop and ask for the correct working directory.
+1. **Confirm repo root** — Require `developer_graph/api.py` and `start_dev_graph.ps1`. If missing, stop and ask for the correct working directory.
 
-2. Decide the requested mode
-- full: Neo4j + API + UI
-- backend: Neo4j + API only
-- services: just Neo4j
-- frontend: only Dev Graph UI
-- status: report what is running
-- stop: stop Docker services and list any remaining processes
+2. **Decide mode:**
+   | Mode | Services |
+   |------|----------|
+   | `full` | Neo4j + API + UI |
+   | `backend` | Neo4j + API only |
+   | `services` | Neo4j only |
+   | `frontend` | Dev Graph UI only |
+   | `status` | Report what is running |
+   | `stop` | Stop Docker services |
 
-3. Docker preflight
-- Check Docker CLI and Docker Compose:
-  - `docker version`
-  - `docker compose version`
-- If Docker is installed but not running, say so and stop.
+3. **Docker preflight** — Verify Docker is running: `docker version` and `docker compose version`. If Docker is installed but not running, say so and stop.
 
-4. Start sequence
-- full: run `.\start_dev_graph.ps1`
-- backend:
-  - `docker compose up -d neo4j`
-  - `uvicorn developer_graph.api:app --host 0.0.0.0 --port 8080 --reload`
-- services:
-  - `docker compose up -d neo4j`
-- frontend:
-  - `cd tools/dev-graph-ui` then `npm run dev`
+4. **Start services** per mode:
+   - `services`: `docker compose up -d neo4j`
+   - `backend`: `docker compose up -d neo4j` then `uvicorn developer_graph.api:app --host 0.0.0.0 --port 8080 --reload`
+   - `frontend`: `cd tools/dev-graph-ui && npm run dev`
+   - `full`: Run the startup script (combines all above)
 
-When launching uvicorn or npm, use new terminal windows so the main session stays responsive.
+   Launch uvicorn or npm in new terminal windows so the main session stays responsive.
 
-5. Status checks
-- `docker compose ps`
-- The script prints a port readiness summary (7474/7687/8080/3001).
-- Report URLs:
-  - http://localhost:3001
-  - http://localhost:8080/docs
-  - http://localhost:7474
-  - http://localhost:3001/dev-graph/timeline
-  - http://localhost:3001/dev-graph/structure
+5. **Verify** — Check `docker compose ps` and confirm ports are reachable:
+   - UI: http://localhost:3001
+   - API docs: http://localhost:8080/docs
+   - Neo4j browser: http://localhost:7474
+   - Timeline: http://localhost:3001/dev-graph/timeline
+   - Structure: http://localhost:3001/dev-graph/structure
 
-6. Stop sequence
-- `docker compose down`
-- Remind the user to close any uvicorn or npm windows still running.
+6. **Stop** — `docker compose down`. Remind the user to close any uvicorn or npm terminal windows.
 
 ## Notes
-- Docker Compose service name is `neo4j` in `docker-compose.yml`.
-- The Windows batch script uses `neo4j_db`; do not copy that name here.
-- Do not redirect uvicorn output to `dev_graph_api.log` in the repo root. The app writes the same file and will raise a permission error.
-- The UI may choose port 3001 if 3000 is already in use; the script expects 3001.
 
-## Script
-- Run: `powershell -ExecutionPolicy Bypass -File skills\\start-dev-graph\\scripts\\start_dev_graph.ps1 -Mode full`
-- Backend only: `-Mode backend`
-- Frontend + open page: `-Mode frontend -Open -Page /dev-graph/structure`
-- Note: `-Open` is required to open a browser; `-Page` alone will not open anything.
+- Docker Compose service name is `neo4j` (not `neo4j_db` from the batch script).
+- Do not redirect uvicorn output to `dev_graph_api.log` — the app writes the same file and raises a permission error.
+- The UI defaults to port 3001 if 3000 is in use; the script expects 3001.

--- a/skills/start-pixel-detective/SKILL.md
+++ b/skills/start-pixel-detective/SKILL.md
@@ -1,74 +1,63 @@
 ---
 name: start-pixel-detective
-description: Start, stop, or check Pixel Detective services on this machine. Use when the user asks to start Pixel Detective, start backend only, start full stack, restart, stop, or check Docker, Qdrant, ML, UMAP, or frontend status, or to provide a specific Pixel Detective page URL.
+description: "Start, stop, or check Pixel Detective services on this machine. Use when the user asks to start Pixel Detective, launch backend only, start full stack, restart, stop, or check Docker, Qdrant, ML inference, UMAP, or frontend status, or to provide a specific Pixel Detective page URL."
 ---
 
 # Start Pixel Detective
 
-Use this skill to run Pixel Detective locally with the right subset of services.
+Run Pixel Detective locally with the right subset of services.
 
 ## Quickstart
-- Full stack: `powershell -ExecutionPolicy Bypass -File skills\\start-pixel-detective\\scripts\\start_pixel_detective.ps1 -Mode full`
-- Backend only (+ optional GPU UMAP): `powershell -ExecutionPolicy Bypass -File skills\\start-pixel-detective\\scripts\\start_pixel_detective.ps1 -Mode backend -UseGpuUmap`
+
+```bash
+# Full stack
+powershell -ExecutionPolicy Bypass -File skills\start-pixel-detective\scripts\start_pixel_detective.ps1 -Mode full
+
+# Backend only (+ optional GPU UMAP)
+powershell -ExecutionPolicy Bypass -File skills\start-pixel-detective\scripts\start_pixel_detective.ps1 -Mode backend -UseGpuUmap
+
+# Frontend + open browser
+powershell -ExecutionPolicy Bypass -File skills\start-pixel-detective\scripts\start_pixel_detective.ps1 -Mode frontend -Open -Page /search
+```
+
+Note: `-Open` is required to open a browser; `-Page` alone will not open anything.
 
 ## Workflow
 
-1. Confirm repo root
-- Require `frontend/package.json` and `start_pixel_detective.ps1`.
-- If missing, stop and ask for the correct working directory.
+1. **Confirm repo root** — Require `frontend/package.json` and `start_pixel_detective.ps1`. If missing, stop and ask for the correct working directory.
 
-2. Decide the requested mode
-- full: all services plus frontend
-- backend: Qdrant + ML + ingestion (optional UMAP)
-- services: just Docker services (Qdrant and optional GPU UMAP)
-- frontend: only Next.js dev server
-- status: report what is running
-- stop: stop Docker services and list any remaining processes
+2. **Decide mode:**
+   | Mode | Services |
+   |------|----------|
+   | `full` | All services + frontend |
+   | `backend` | Qdrant + ML + ingestion (optional UMAP) |
+   | `services` | Docker only (Qdrant, optional GPU UMAP) |
+   | `frontend` | Next.js dev server only |
+   | `status` | Report what is running |
+   | `stop` | Stop Docker services |
 
-3. Docker preflight
-- Check Docker CLI and Docker Compose:
-  - `docker version`
-  - `docker compose version`
-- If Docker is installed but not running, say so and stop.
+3. **Docker preflight** — Verify Docker is running: `docker version` and `docker compose version`. If Docker is installed but not running, say so and stop.
 
-4. Start sequence
-- full: run `.\start_pixel_detective.ps1`
-- backend:
-  - `docker compose up -d qdrant_db`
-  - optional GPU UMAP: `docker compose -f backend/gpu_umap_service/docker-compose.dev.yml up -d --build`
-  - start ML service: `uvicorn backend.ml_inference_fastapi_app.main:app --port 8001 --reload`
-  - start ingestion: `uvicorn backend.ingestion_orchestration_fastapi_app.main:app --port 8002 --reload`
-- services:
-  - `docker compose up -d qdrant_db`
-  - optional GPU UMAP (same command as above)
-- frontend:
-  - `cd frontend` then `npm run dev`
+4. **Start services** per mode:
+   - `services`: `docker compose up -d qdrant_db` (optional GPU UMAP: `docker compose -f backend/gpu_umap_service/docker-compose.dev.yml up -d --build`)
+   - `backend`: Start Qdrant, then ML inference (`uvicorn backend.ml_inference_fastapi_app.main:app --port 8001 --reload`) and ingestion (`uvicorn backend.ingestion_orchestration_fastapi_app.main:app --port 8002 --reload`)
+   - `frontend`: `cd frontend && npm run dev`
+   - `full`: Run the startup script (combines all above)
 
-When launching uvicorn or npm, use new terminal windows so the main session stays responsive.
+   Launch uvicorn or npm in new terminal windows so the main session stays responsive.
 
-5. Status checks
-- `docker compose ps`
-- The script prints a port readiness summary (6333/8001/8002/8003/3000).
-- Report URLs:
-  - http://localhost:3000
-  - http://localhost:8002/docs
-  - http://localhost:8001/docs
-  - http://localhost:8003/docs
-  - http://localhost:6333/dashboard
+5. **Verify** — Check `docker compose ps` and confirm ports are reachable:
+   - Frontend: http://localhost:3000
+   - Ingestion API: http://localhost:8002/docs
+   - ML inference API: http://localhost:8001/docs
+   - GPU UMAP API: http://localhost:8003/docs
+   - Qdrant dashboard: http://localhost:6333/dashboard
 
-6. Stop sequence
-- `docker compose down`
-- The script attempts to close uvicorn and npm windows tied to this repo.
+6. **Stop** — `docker compose down`. The script attempts to close uvicorn and npm windows tied to this repo.
 
 ## Notes
-- The GPU UMAP service can fail without blocking the rest. Treat it as optional.
-- Use existing startup scripts whenever possible to stay aligned with repo behavior.
-- Qdrant is the only required Docker service for Pixel Detective; ML and ingestion run on the host.
-- If port 3000 is already in use, Next.js will choose 3001 or another port; report the actual port from the terminal output.
-- If the ML or ingestion uvicorn process exits immediately, check for missing Python dependencies or a virtualenv not being activated.
 
-## Script
-- Run: `powershell -ExecutionPolicy Bypass -File skills\\start-pixel-detective\\scripts\\start_pixel_detective.ps1 -Mode full`
-- Backend only: `-Mode backend -UseGpuUmap`
-- Frontend + open page: `-Mode frontend -Open -Page /search`
-- Note: `-Open` is required to open a browser; `-Page` alone will not open anything.
+- GPU UMAP can fail without blocking the rest — treat it as optional.
+- Qdrant is the only required Docker service; ML and ingestion run on the host.
+- If port 3000 is in use, Next.js picks another port; report the actual port from terminal output.
+- If ML or ingestion uvicorn exits immediately, check for missing Python dependencies or an inactive virtualenv.


### PR DESCRIPTION
Hey @Randroids-Dojo 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/d0b2c2a9-03aa-4ba4-9fe5-771e8dd990bf" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| loop | 57% | 86% | +29% |
| unreal | 65% | 83% | +18% |
| task-tracking-dots | 81% | 97% | +16% |
| godot | 86% | 89% | +3% |
| slipbox | 86% | 86% | 0% |

This PR is intentionally scoped to all five skills in the repo — kept reviewable as a single contribution.

<details>
<summary>Changes made</summary>

**loop** (+29%):
- Rewrote description with natural trigger terms ("hands-off coding", "automated development loops") and explicit "Use when" clause
- Condensed verbose startup flow from individual subsections into a compact table
- Replaced pseudocode orchestration loop with concise behavioral description
- Added setup-loop.sh exit code verification step
- Consolidated redundant usage examples

**unreal** (+18%):
- Added explicit "Use when" clause with common trigger terms (UE5, editor scripting, .uproject)
- Made Setup Checklist actionable with specific Editor menu paths and plugin names
- Added Remote Control health check verification step (curl)
- Clearly labeled PlayUnreal Python API as "not yet released" vs working Quick Reference commands
- Added selector strategy comparison table

**task-tracking-dots** (+16%):
- Expanded description with concrete actions (create, list, complete, block) and natural trigger terms (todos, task list, progress)
- Removed redundant "When to use this skill" section that duplicated the description
- Quoted description and compatibility fields in frontmatter

**godot** (+3%):
- Moved inline GdUnit4 assertions and Scene Runner Input API to reference file pointers (references/assertions.md, references/scene-runner.md)
- Moved inline PlayGodot API catalog to reference file pointer (references/playgodot.md)
- Added build export validation step (test -f) and deployment verification (curl health check)
- Quoted description in frontmatter

**slipbox** (0%):
- Removed duplicate Quick Reference section (API Reference already contains the same curl commands with more detail)
- Quoted compatibility field in frontmatter

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
